### PR TITLE
Pretty printer for parsed IL values

### DIFF
--- a/p4spec/lib/il/eq.ml
+++ b/p4spec/lib/il/eq.ml
@@ -73,6 +73,32 @@ and eq_typ (typ_a : typ) (typ_b : typ) : bool =
 and eq_typs (typs_a : typ list) (typs_b : typ list) : bool =
   List.length typs_a = List.length typs_b && List.for_all2 eq_typ typs_a typs_b
 
+(* Values *)
+
+and eq_value (value_a : value) (value_b : value) : bool =
+  match (value_a.it, value_b.it) with
+  | BoolV b_a, BoolV b_b -> b_a = b_b
+  | NumV n_a, NumV n_b -> Num.eq n_a n_b
+  | TextV t_a, TextV t_b -> t_a = t_b
+  | StructV valuefields_a, StructV valuefields_b ->
+      List.length valuefields_a = List.length valuefields_b
+      && List.for_all2
+           (fun (atom_a, value_a) (atom_b, value_b) ->
+             eq_atom atom_a atom_b && eq_value value_a value_b)
+           valuefields_a valuefields_b
+  | CaseV (mixop_a, values_a), CaseV (mixop_b, values_b) ->
+      eq_mixop mixop_a mixop_b && eq_values values_a values_b
+  | TupleV values_a, TupleV values_b -> eq_values values_a values_b
+  | OptV (Some v_a), OptV (Some v_b) -> eq_value v_a v_b
+  | OptV None, OptV None -> true
+  | ListV values_a, ListV values_b -> eq_values values_a values_b
+  | FuncV id_a, FuncV id_b -> id_a = id_b
+  | _ -> false
+
+and eq_values (values_a : value list) (values_b : value list) : bool =
+  List.length values_a = List.length values_b
+  && List.for_all2 eq_value values_a values_b
+
 (* Expressions *)
 
 and eq_exp (exp_a : exp) (exp_b : exp) : bool =

--- a/p4spec/lib/parsing/ast_utils.ml
+++ b/p4spec/lib/parsing/ast_utils.ml
@@ -46,6 +46,11 @@ let id_of_case_v (v : value) : string =
   | CaseV _, VarT (id, _) -> id.it
   | _ -> failwith "not a case value"
 
+let id_of_list_v (v : value) : string =
+  match (v.it, v.note.typ) with
+  | ListV _, VarT (id, _) -> id.it
+  | _ -> failwith "not a list value"
+
 type syntax' = string list list * value' list
 type syntax = string list list * value list
 

--- a/p4spec/lib/parsing/ast_utils.ml
+++ b/p4spec/lib/parsing/ast_utils.ml
@@ -48,7 +48,8 @@ let id_of_case_v (v : value) : string =
 
 let id_of_list_v (v : value) : string =
   match (v.it, v.note.typ) with
-  | ListV _, VarT (id, _) -> id.it
+  | ListV _, IterT ({ it = VarT (id, _); _ }, _) -> id.it
+  | ListV _, IterT (_, _) -> failwith "ill-typed list value"
   | _ -> failwith "not a list value"
 
 type syntax' = string list list * value' list

--- a/p4spec/lib/parsing/parse.ml
+++ b/p4spec/lib/parsing/parse.ml
@@ -23,11 +23,7 @@ let parse (lexbuf : Lexing.lexbuf) =
   with
   | Parser.Error ->
       let info = Lexer.info lexbuf in
-      let pos = Lexing.lexeme_start_p lexbuf in
-      let msg =
-        Format.asprintf "syntax error at line %d, column %d" pos.Lexing.pos_lnum
-          (pos.Lexing.pos_cnum - pos.Lexing.pos_bol)
-      in
+      let msg = Format.asprintf "syntax error" in
       error (Source.to_region info) msg
   | e -> raise e
 

--- a/p4spec/lib/parsing/parser.mly
+++ b/p4spec/lib/parsing/parser.mly
@@ -728,7 +728,7 @@ expression:
     { info1 |> ignore;
       [ Term "ERROR"; Term "."; NT name ] |> wrap_case_v |> with_typ (wrap_var_t "expression") }
 | expr = expression DOT name = member
-    { [ NT expr; Term "."; NT name ] |> wrap_case_v |> with_typ (wrap_var_t "expression") }
+    { [ NT expr; Term "."; NT name; Term "PHTM_5" ] |> wrap_case_v |> with_typ (wrap_var_t "expression") }
 | arg1 = expression op = binop arg2 = expression
     { [ NT arg1; Term op; NT arg2 ] |> wrap_case_v |> with_typ (wrap_var_t "expression") }
 | cond = expression QUESTION tru = expression COLON fls = expression
@@ -742,7 +742,7 @@ expression:
       [ NT func; Term "("; NT args; Term ")" ] |> wrap_case_v |> with_typ (wrap_var_t "expression") }
 | typ = namedType L_PAREN args = argumentList info2 = R_PAREN
     { info2 |> ignore;
-      [ NT typ; Term "("; NT args; Term ")" ] |> wrap_case_v |> with_typ (wrap_var_t "expression") }
+      [ NT typ; Term "("; NT args; Term ")"; Term "PHTM_6" ] |> wrap_case_v |> with_typ (wrap_var_t "expression") }
 ;
 
 %inline expressionList:

--- a/p4spec/lib/parsing/parser.mly
+++ b/p4spec/lib/parsing/parser.mly
@@ -669,7 +669,7 @@ expression:
 | info1 = FALSE
     { info1 |> ignore;
       [ Term "FALSE" ] |> wrap_case_v |> with_typ (wrap_var_t "expression") }
-| value = STRING_LITERAL
+| value = stringLiteral
     { value }
 | info1 = THIS
     { info1 |> ignore;

--- a/p4spec/lib/parsing/parser.mly
+++ b/p4spec/lib/parsing/parser.mly
@@ -356,7 +356,7 @@ name:
 (* From Petr4: optional trailing comma *)
 identifierList:
 | ids = separated_nonempty_opt_trailing_list(COMMA, id = name { id })
-    { wrap_list_v "identifier" ids }
+    { wrap_list_v "name" ids }
 ;
 member:
 | name = name
@@ -510,7 +510,7 @@ typeOrVoid:
 
 typeParameterList:
 | names = separated_nonempty_list(COMMA, name) 
-    { wrap_list_v "typeParameterList" names }
+    { wrap_list_v "name" names }
 ;
 typeParameters:
 | l_angle type_params = typeParameterList r_angle
@@ -1102,12 +1102,12 @@ forInitStatements:
 ;
 forUpdateStatementsNonEmpty:
 | assignments = separated_nonempty_list(COMMA, assignmentOrMethodCallStatementWithoutSemicolon)
-    { wrap_list_v "assignmentOrMethodCallStatement" assignments }
+    { wrap_list_v "assignmentOrMethodCallStatementWithoutSemicolon" assignments }
 ;
 
 forUpdateStatements:
 | assignments = separated_list(COMMA, assignmentOrMethodCallStatementWithoutSemicolon)
-    { wrap_list_v "assignmentOrMethodCallStatement" assignments }
+    { wrap_list_v "assignmentOrMethodCallStatementWithoutSemicolon" assignments }
 ;
 
 forCollectionExpr:

--- a/p4spec/lib/parsing/pp.ml
+++ b/p4spec/lib/parsing/pp.ml
@@ -357,8 +357,45 @@ and pp_syntax_expr fmt (value : value) : unit =
            value)
   | _ ->
       failwith
-        (Printf.sprintf "@pp_syntax_nb_expr: expected expression, got %s"
+        (Printf.sprintf "@pp_syntax_expr: expected expression, got %s"
            (id_of_case_v value))
+
+and pp_syntax_keyset_expr fmt (value : value) : unit =
+  match flatten_case_v value with
+  | "simpleKeysetExpression", [ []; [ "&&&" ]; [] ], [ expr; mask ] ->
+      F.fprintf fmt "(%a) &&& (%a)" pp_case_v expr pp_case_v mask
+  | "simpleKeysetExpression", [ []; [ ".." ]; [] ], [ lo; hi ] ->
+      F.fprintf fmt "(%a) .. (%a)" pp_case_v lo pp_case_v hi
+  | "simpleKeysetExpression", [ [ "_" ] ], [] -> F.fprintf fmt "_"
+  | "simpleKeysetExpression", [ [ "DEFAULT" ] ], [] -> F.fprintf fmt "default"
+  | "simpleKeysetExpression", _, _ ->
+      failwith
+        (F.asprintf
+           "@pp_syntax_keyset_expr: ill-formed simple keyset expression:\n%a"
+           pp_case_v value)
+  | "reducedSimpleKeysetExpression", [ []; [ "&&&" ]; [] ], [ expr; mask ] ->
+      F.fprintf fmt "(%a) &&& (%a)" pp_case_v expr pp_case_v mask
+  | "reducedSimpleKeysetExpression", [ []; [ ".." ]; [] ], [ lo; hi ] ->
+      F.fprintf fmt "(%a) .. (%a)" pp_case_v lo pp_case_v hi
+  | "reducedSimpleKeysetExpression", [ [ "_" ] ], [] -> F.fprintf fmt "_"
+  | "reducedSimpleKeysetExpression", [ [ "DEFAULT" ] ], [] ->
+      F.fprintf fmt "default"
+  | "reducedSimpleKeysetExpression", _, _ ->
+      failwith
+        (F.asprintf
+           "@pp_syntax_keyset_expr: ill-formed reduced simple keyset expression:\n\
+            %a"
+           pp_case_v value)
+  | "tupleKeysetExpression", [ [ "(" ]; [ "," ]; [ ")" ] ], [ expr; exprs ] ->
+      F.fprintf fmt "(%a, %a)" pp_case_v expr (pp_list_v ~sep:Comma) exprs
+  | "tupleKeysetExpression", [ [ "(" ]; [ ")"; "PHTM_19" ] ], [ expr ] ->
+      F.fprintf fmt "(%a)" pp_case_v expr
+  | "tupleKeysetExpression", _, _ ->
+      failwith
+        (F.asprintf
+           "@pp_syntax_keyset_expr: ill-formed tuple keyset expression:\n%a"
+           pp_case_v value)
+  | _ -> failwith "@pp_syntax_keyset_expr: not yet implemented"
 
 and pp_syntax_type_arg _fmt (value : value) : unit =
   match flatten_case_v value with
@@ -483,6 +520,9 @@ and pp_case_v' fmt (value : value) : unit =
   | "dotPrefix", [ [ "." ] ], [] -> F.fprintf fmt "."
   (* Type references *)
   | "typeOrVoid", [ [ "VOID" ] ], [] -> F.fprintf fmt "void"
+  (* Key value pair *)
+  | "kvPair", [ []; [ "=" ]; [] ], [ key; value ] ->
+      F.fprintf fmt "(%a) = (%a)" pp_case_v key pp_case_v value
   | _ -> pp_default_case_v fmt value
 
 and pp_case_v fmt (value : value) : unit =
@@ -505,4 +545,7 @@ and pp_case_v fmt (value : value) : unit =
   | "parameter" | "constructorParameters" -> pp_syntax_params fmt value
   | "nonBraceExpression" -> pp_syntax_nb_expr fmt value
   | "expression" -> pp_syntax_expr fmt value
+  | "simpleKeysetExpression" | "reducedSimpleKeysetExpression"
+  | "tupleKeysetExpression" ->
+      pp_syntax_keyset_expr fmt value
   | _ -> pp_case_v' fmt value

--- a/p4spec/lib/parsing/pp.ml
+++ b/p4spec/lib/parsing/pp.ml
@@ -9,6 +9,8 @@ module F = Format
 
 let verbose = ref false
 
+(* Atoms *)
+
 let pp_atom fmt (atom : atom) : unit =
   F.fprintf fmt "%s" (Atom.string_of_atom atom.it)
 
@@ -23,28 +25,17 @@ let pp_atoms fmt (atoms : atom list) : unit =
       in
       F.fprintf fmt "%s" (String.concat "" atoms)
 
-let rec pp_default_case_v fmt value : unit =
-  match value.it with
-  | CaseV (mixop, values) ->
-      let len = List.length mixop + List.length values in
-      List.init len (fun idx ->
-          if idx mod 2 = 0 then
-            idx / 2 |> List.nth mixop |> F.asprintf "%a" pp_atoms
-          else idx / 2 |> List.nth values |> F.asprintf "%a" pp_value)
-      |> List.filter (fun str -> str <> "")
-      |> String.concat " "
-      |>
-      if !verbose then F.fprintf fmt "@%s_< %s>_@" (id_of_case_v value)
-      else F.fprintf fmt "%s"
-  | _ -> failwith "@pp_default_case_v: Expected CaseV value"
+(* Numbers *)
 
-and pp_num fmt (num : num) : unit =
+let rec pp_num fmt (num : num) : unit =
   match num with
   | `Nat n -> F.fprintf fmt "%s" (Bigint.to_string n)
   | `Int i ->
       F.fprintf fmt "%s"
         ((if i >= Bigint.zero then "" else "-")
         ^ Bigint.to_string (Bigint.abs i))
+
+(* IL Values *)
 
 and pp_value fmt (value : value) : unit =
   match value.it with
@@ -61,17 +52,23 @@ and pp_value fmt (value : value) : unit =
   | ListV _ -> pp_list_v ~sep:Nl fmt value
   | _ -> failwith "@pp_value: TODO"
 
+(* TextV *)
+
 and pp_text_v ~escaped fmt (value : value) : unit =
   match value.it with
   | TextV text ->
       if escaped then F.fprintf fmt "%S" text else F.fprintf fmt "%s" text
   | _ -> failwith "@pp_text_v: expected TextV value"
 
+(* OptV *)
+
 and pp_opt_v ?(postfix = "") pp_v fmt (value : value) : unit =
   match value.it with
   | OptV (Some v) -> F.fprintf fmt "%a%s" pp_v v postfix
   | OptV None -> F.fprintf fmt ""
   | _ -> failwith "@pp_opt_v: expected OptV value"
+
+(* ListV *)
 
 and pp_list_v ?(level = 0) ~sep fmt (value : value) : unit =
   let values =
@@ -112,6 +109,87 @@ and pp_list_v ?(level = 0) ~sep fmt (value : value) : unit =
       failwith
         (Printf.sprintf "@pp_list_v: unknown ListV: %s" (id_of_list_v value))
 
+(* Default CaseV *)
+
+and pp_default_case_v fmt value : unit =
+  match value.it with
+  | CaseV (mixop, values) ->
+      let len = List.length mixop + List.length values in
+      List.init len (fun idx ->
+          if idx mod 2 = 0 then
+            idx / 2 |> List.nth mixop |> F.asprintf "%a" pp_atoms
+          else idx / 2 |> List.nth values |> F.asprintf "%a" pp_value)
+      |> List.filter (fun str -> str <> "")
+      |> String.concat " "
+      |>
+      if !verbose then F.fprintf fmt "@%s_< %s>_@" (id_of_case_v value)
+      else F.fprintf fmt "%s"
+  | _ -> failwith "@pp_default_case_v: Expected CaseV value"
+
+(* Trailing commas *)
+
+and pp_syntax_comma fmt (value : value) : unit =
+  match flatten_case_v value with
+  | "trailingComma", [ [ ","; "PHTM_0" ] ], [] -> F.fprintf fmt ","
+  | "trailingComma", _, _ ->
+      failwith
+        (F.asprintf "@pp_syntax_comma: ill-formed trailing comma:\n%a"
+           pp_default_case_v value)
+  | _ ->
+      failwith
+        (Printf.sprintf "@pp_syntax_comma: expected trailing comma, got %s"
+           (id_of_case_v value))
+
+(* Const *)
+
+and pp_syntax_const fmt (value : value) : unit =
+  match flatten_case_v value with
+  | "const", [ [ "CONST" ] ], [] -> F.fprintf fmt "const"
+  | "const", _, _ ->
+      failwith
+        (F.asprintf "@pp_syntax_const: ill-formed const:\n%a" pp_default_case_v
+           value)
+  | _ ->
+      failwith
+        (Printf.sprintf "@pp_syntax_const: expected const, got %s"
+           (id_of_case_v value))
+
+(* Numbers *)
+
+and pp_syntax_num fmt (value : value) : unit =
+  match flatten_case_v value with
+  | "number", [ []; [ "PHTM_1" ] ], [ value_int ] ->
+      F.fprintf fmt "%a" pp_value value_int
+  | "number", [ []; [ "S" ]; [] ], [ value_width; value_int ] ->
+      F.fprintf fmt "%as%a" pp_value value_width pp_value value_int
+  | "number", [ []; [ "W" ]; [] ], [ value_width; value_int ] ->
+      F.fprintf fmt "%aw%a" pp_value value_width pp_value value_int
+  | "number", _, _ ->
+      failwith
+        (F.asprintf "@pp_syntax_num: ill-formed number:\n%a" pp_default_case_v
+           value)
+  | _ ->
+      failwith
+        (Printf.sprintf "@pp_syntax_num: expected number, got %s"
+           (id_of_case_v value))
+
+(* Strings *)
+
+and pp_syntax_str fmt (value : value) : unit =
+  match flatten_case_v value with
+  | "stringLiteral", [ []; [ "PHTM_2" ] ], [ value_text ] ->
+      F.fprintf fmt "%a" (pp_text_v ~escaped:true) value_text
+  | "stringLiteral", _, _ ->
+      failwith
+        (F.asprintf "@pp_syntax_str: ill-formed string:\n%a" pp_default_case_v
+           value)
+  | _ ->
+      failwith
+        (Printf.sprintf "@pp_syntax_str: expected string, got %s"
+           (id_of_case_v value))
+
+(* Identifiers *)
+
 and pp_syntax_id fmt (value : value) : unit =
   match flatten_case_v value with
   | "identifier", [ [ "$" ]; [] ], [ value_text ] ->
@@ -124,6 +202,8 @@ and pp_syntax_id fmt (value : value) : unit =
       failwith
         (Printf.sprintf "@pp_syntax_id: expected identifier, got %s"
            (id_of_case_v value))
+
+(* Type identifiers *)
 
 and pp_syntax_tid fmt (value : value) : unit =
   match flatten_case_v value with
@@ -138,8 +218,11 @@ and pp_syntax_tid fmt (value : value) : unit =
         (Printf.sprintf "@pp_syntax_tid: expected typeIdentifier, got %s"
            (id_of_case_v value))
 
+(* Names *)
+
 and pp_syntax_name fmt (value : value) : unit =
   match flatten_case_v value with
+  | "dotPrefix", [ [ "." ] ], [] -> F.fprintf fmt "."
   | "nonTypeName", [ [ "APPLY" ] ], [] -> F.fprintf fmt "apply"
   | "nonTypeName", [ [ "KEY" ] ], [] -> F.fprintf fmt "key"
   | "nonTypeName", [ [ "ACTIONS" ] ], [] -> F.fprintf fmt "actions"
@@ -157,6 +240,8 @@ and pp_syntax_name fmt (value : value) : unit =
         (Printf.sprintf "@pp_syntax_name: expected name, got %s"
            (id_of_case_v value))
 
+(* Directions *)
+
 and pp_syntax_dir fmt (value : value) : unit =
   match flatten_case_v value with
   | "direction", [ [ "IN" ] ], [] -> F.fprintf fmt "in "
@@ -170,6 +255,8 @@ and pp_syntax_dir fmt (value : value) : unit =
       failwith
         (Printf.sprintf "@pp_syntax_dir: expected direction, got %s"
            (id_of_case_v value))
+
+(* Types *)
 
 and pp_syntax_type fmt (value : value) : unit =
   match flatten_case_v value with
@@ -222,10 +309,13 @@ and pp_syntax_type fmt (value : value) : unit =
       failwith
         (F.asprintf "@pp_syntax_type: ill-formed tuple type:\n%a" pp_case_v
            value)
+  | "typeOrVoid", [ [ "VOID" ] ], [] -> F.fprintf fmt "void"
   | _ ->
       failwith
         (Printf.sprintf "@pp_syntax_type: expected type, got %s"
            (id_of_case_v value))
+
+(* Type parameters *)
 
 and pp_syntax_tparams fmt (value : value) : unit =
   match flatten_case_v value with
@@ -240,17 +330,19 @@ and pp_syntax_tparams fmt (value : value) : unit =
         (Printf.sprintf "@pp_syntax_tparams: expected type parameters, got %s"
            (id_of_case_v value))
 
+(* Parameters *)
+
 and pp_syntax_params fmt (value : value) : unit =
   match flatten_case_v value with
   | "parameter", [ []; []; []; []; [] ], [ opt_annos; dir; type_ref; name ] ->
       F.fprintf fmt "%a%a%a %a"
-        (pp_opt_annos ~level:0 ~sep:SpaceSep)
+        (pp_opt_annos ~level:0 ~sep:Space)
         opt_annos pp_case_v dir pp_case_v type_ref pp_case_v name
   | ( "parameter",
       [ []; []; []; []; []; [] ],
       [ opt_annos; dir; type_ref; name; init ] ) ->
       F.fprintf fmt "%a%a%a %a%a"
-        (pp_opt_annos ~level:0 ~sep:SpaceSep)
+        (pp_opt_annos ~level:0 ~sep:Space)
         opt_annos pp_case_v dir pp_case_v type_ref pp_case_v name pp_case_v init
   | "parameter", _, _ ->
       failwith
@@ -262,6 +354,8 @@ and pp_syntax_params fmt (value : value) : unit =
       failwith
         (Printf.sprintf "@pp_syntax_params: expected parameter, got %s"
            (id_of_case_v value))
+
+(* Non-brace expressions *)
 
 and pp_syntax_nb_expr fmt (value : value) : unit =
   let is_binary_op = function
@@ -323,6 +417,8 @@ and pp_syntax_nb_expr fmt (value : value) : unit =
         (Printf.sprintf
            "@pp_syntax_nb_expr: expected non-brace expression, got %s"
            (id_of_case_v value))
+
+(* Expressions *)
 
 and pp_syntax_expr fmt (value : value) : unit =
   let is_binary_op = function
@@ -405,6 +501,8 @@ and pp_syntax_expr fmt (value : value) : unit =
         (Printf.sprintf "@pp_syntax_expr: expected expression, got %s"
            (id_of_case_v value))
 
+(* Keyset expressions *)
+
 and pp_syntax_keyset_expr fmt (value : value) : unit =
   match flatten_case_v value with
   | "simpleKeysetExpression", [ []; [ "&&&" ]; [] ], [ expr; mask ] ->
@@ -448,6 +546,23 @@ and pp_syntax_keyset_expr fmt (value : value) : unit =
            "@pp_syntax_keyset_expr: expected keyset expression, got %s"
            (id_of_case_v value))
 
+(* Key value pairs *)
+
+and pp_syntax_kvpair fmt (value : value) : unit =
+  match flatten_case_v value with
+  | "kvPair", [ []; [ "=" ]; [] ], [ key; value ] ->
+      F.fprintf fmt "%a = %a" pp_case_v key pp_case_v value
+  | "kvPair", _, _ ->
+      failwith
+        (F.asprintf "@pp_syntax_kvpair: ill-formed key value pair:\n%a"
+           pp_case_v value)
+  | _ ->
+      failwith
+        (Printf.sprintf "@pp_syntax_kvpair: expected key value pair, got %s"
+           (id_of_case_v value))
+
+(* Type arguments *)
+
 and pp_syntax_targ fmt (value : value) : unit =
   match flatten_case_v value with
   | "realTypeArg", [ [ "VOID" ] ], [] -> F.fprintf fmt "void"
@@ -467,6 +582,8 @@ and pp_syntax_targ fmt (value : value) : unit =
         (Printf.sprintf "@pp_syntax_targ: expected type argument, got %s"
            (id_of_case_v value))
 
+(* Arguments *)
+
 and pp_syntax_arg fmt (value : value) : unit =
   match flatten_case_v value with
   | "argument", [ []; [ "=" ]; [] ], [ name; expr ] ->
@@ -481,6 +598,8 @@ and pp_syntax_arg fmt (value : value) : unit =
       failwith
         (Printf.sprintf "@pp_syntax_arg: expected argument, got %s"
            (id_of_case_v value))
+
+(* L-values *)
 
 and pp_syntax_lvalue fmt (value : value) : unit =
   match flatten_case_v value with
@@ -501,6 +620,8 @@ and pp_syntax_lvalue fmt (value : value) : unit =
         (Printf.sprintf "@pp_syntax_lvalue: expected l-value, got %s"
            (id_of_case_v value))
 
+(* Initializers *)
+
 and pp_syntax_init fmt (value : value) : unit =
   match flatten_case_v value with
   | "initializer", [ [ "=" ]; [] ], [ expr ] ->
@@ -513,6 +634,8 @@ and pp_syntax_init fmt (value : value) : unit =
       failwith
         (Printf.sprintf "@pp_syntax_init: expected initializer, got %s"
            (id_of_case_v value))
+
+(* Statements *)
 
 and pp_syntax_stmt' ~level fmt (value : value) : unit =
   let is_assign_op = function
@@ -615,13 +738,15 @@ and pp_syntax_stmt ~level fmt (value : value) : unit =
       F.fprintf fmt "%afor (%a%a %a in %a) %a"
         (pp_opt_annos ~level ~sep:Nl)
         opt_annos
-        (pp_opt_annos ~level:0 ~sep:SpaceSep)
+        (pp_opt_annos ~level:0 ~sep:Space)
         opt_annos_in pp_case_v typ pp_case_v name pp_case_v collection
         (pp_syntax_stmt ~level) body
   | _ ->
       failwith
         (Printf.sprintf "@pp_syntax_stmt: expected statement, got %s"
            (id_of_case_v value))
+
+(* Function prototypes *)
 
 and pp_syntax_func fmt (value : value) : unit =
   match flatten_case_v value with
@@ -641,6 +766,8 @@ and pp_syntax_func fmt (value : value) : unit =
       failwith
         (Printf.sprintf "@pp_syntax_func: expected function prototype, got %s"
            (id_of_case_v value))
+
+(* Method prototypes *)
 
 and pp_syntax_mthd ~level fmt (value : value) : unit =
   match flatten_case_v value with
@@ -669,6 +796,8 @@ and pp_syntax_mthd ~level fmt (value : value) : unit =
         (Printf.sprintf "@pp_syntax_method: expected methodPrototype, got %s"
            (id_of_case_v value))
 
+(* Statements or declarations in block statements *)
+
 and pp_syntax_stat_or_decl ~level fmt (value : value) : unit =
   match id_of_case_v value with
   | "variableDeclaration" | "constantDeclaration" ->
@@ -685,6 +814,8 @@ and pp_syntax_stat_or_decl ~level fmt (value : value) : unit =
             declaration, or statement, got %s"
            (id_of_case_v value))
 
+(* Statements in for init statements *)
+
 and pp_syntax_decl_or_assign_or_call_stmt fmt (value : value) : unit =
   match id_of_case_v value with
   | "variableDeclarationWithoutSemicolon" -> pp_case_v fmt value
@@ -697,6 +828,8 @@ and pp_syntax_decl_or_assign_or_call_stmt fmt (value : value) : unit =
             declaration, assignment statement, or method call statement, got \
             %s"
            (id_of_case_v value))
+
+(* Object initializers *)
 
 and pp_syntax_obj_init ~level fmt (value : value) : unit =
   match flatten_case_v value with
@@ -714,13 +847,15 @@ and pp_syntax_obj_init ~level fmt (value : value) : unit =
            "@pp_syntax_obj_init: expected object initializer, got %s"
            (id_of_case_v value))
 
+(* Table key elements *)
+
 and pp_syntax_key fmt (value : value) : unit =
   match flatten_case_v value with
   | "keyElement", [ []; [ ":" ]; []; [ ";" ] ], [ key; match_kind; opt_annos ]
     ->
       let space = match opt_annos.it with OptV (Some _) -> " " | _ -> "" in
       F.fprintf fmt "%a : %a%s%a;" pp_case_v key pp_case_v match_kind space
-        (pp_opt_annos ~level:0 ~sep:SpaceSep)
+        (pp_opt_annos ~level:0 ~sep:Space)
         opt_annos
   | "keyElement", _, _ ->
       failwith
@@ -730,6 +865,8 @@ and pp_syntax_key fmt (value : value) : unit =
       failwith
         (Printf.sprintf "@pp_syntax_key: expected key element, got %s"
            (id_of_case_v value))
+
+(* Table actions *)
 
 and pp_syntax_action_ref fmt (value : value) : unit =
   match flatten_case_v value with
@@ -758,6 +895,8 @@ and pp_syntax_action ~level fmt (value : value) : unit =
         (Printf.sprintf "@pp_syntax_action: expected action, got %s"
            (id_of_case_v value))
 
+(* Table entries *)
+
 and pp_syntax_entry_prio fmt (value : value) : unit =
   match flatten_case_v value with
   | "entryPriority", [ [ "PRIORITY"; "=" ]; [ ":" ] ], [ num ] ->
@@ -782,7 +921,7 @@ and pp_syntax_entry fmt (value : value) : unit =
       F.fprintf fmt "%a%a %a : %a%s%a;"
         (pp_opt_v ~postfix:" " pp_case_v)
         opt_const pp_case_v prio pp_case_v keyset pp_case_v action space
-        (pp_opt_annos ~level:0 ~sep:SpaceSep)
+        (pp_opt_annos ~level:0 ~sep:Space)
         opt_annos
   | ( "entry",
       [ []; []; [ ":" ]; []; [ ";" ] ],
@@ -791,7 +930,7 @@ and pp_syntax_entry fmt (value : value) : unit =
       F.fprintf fmt "%a%a : %a%s%a;"
         (pp_opt_v ~postfix:" " pp_case_v)
         opt_const pp_case_v keyset pp_case_v action space
-        (pp_opt_annos ~level:0 ~sep:SpaceSep)
+        (pp_opt_annos ~level:0 ~sep:Space)
         opt_annos
   | "entry", _, _ ->
       failwith
@@ -800,6 +939,8 @@ and pp_syntax_entry fmt (value : value) : unit =
       failwith
         (Printf.sprintf "@pp_syntax_entry: expected entry, got %s"
            (id_of_case_v value))
+
+(* Table properties *)
 
 and pp_syntax_table_prop ~level fmt (value : value) : unit =
   match flatten_case_v value with
@@ -838,28 +979,7 @@ and pp_syntax_table_prop ~level fmt (value : value) : unit =
         (Printf.sprintf "@pp_syntax_table_prop: expected table property, got %s"
            (id_of_case_v value))
 
-and pp_syntax_ctrl_typ_decl ~level fmt (value : value) : unit =
-  match flatten_case_v value with
-  | ( "controlTypeDeclaration",
-      [ []; [ "CONTROL" ]; []; [ "(" ]; [ ")" ] ],
-      [ opt_annos; name; tparams; params ] ) ->
-      F.fprintf fmt "%acontrol %a%a(%a)"
-        (pp_opt_annos ~level ~sep:Nl)
-        opt_annos pp_case_v name
-        (pp_opt_v ~postfix:"" pp_case_v)
-        tparams
-        (pp_list_v ~level:0 ~sep:Comma)
-        params
-  | "controlTypeDeclaration", _, _ ->
-      failwith
-        (F.asprintf
-           "@pp_syntax_ctrl_typ_decl: ill-formed control type declaration:\n%a"
-           pp_case_v value)
-  | _ ->
-      failwith
-        (Printf.sprintf
-           "@pp_syntax_ctrl_typ_decl: expected control type declaration, got %s"
-           (id_of_case_v value))
+(* Select expressions *)
 
 and pp_syntax_select_case fmt (value : value) : unit =
   match flatten_case_v value with
@@ -894,6 +1014,8 @@ and pp_syntax_select_expr ~level fmt (value : value) : unit =
            "@pp_syntax_select_expr: expected select expression, got %s"
            (id_of_case_v value))
 
+(* Transition statements *)
+
 and pp_syntax_state_expr ~level fmt (value : value) : unit =
   match flatten_case_v value with
   | "stateExpression", [ []; [ ";" ] ], [ name ] ->
@@ -925,6 +1047,8 @@ and pp_syntax_trans_stmt ~level fmt (value : value) : unit =
            "@pp_syntax_trans_stmt: expected transition statement, got %s"
            (id_of_case_v value))
 
+(* Parser and parser type declarations *)
+
 and pp_syntax_parser_stmt ~level fmt (value : value) : unit =
   match flatten_case_v value with
   | "assignmentOrMethodCallStatement", _, _
@@ -936,7 +1060,7 @@ and pp_syntax_parser_stmt ~level fmt (value : value) : unit =
       pp_syntax_decl ~level fmt value
   | "parserBlockStatement", [ []; [ "{" ]; [ "}" ] ], [ opt_annos; stmts ] ->
       F.fprintf fmt "%a{\n%a\n%s}"
-        (pp_opt_annos ~level ~sep:SpaceSep)
+        (pp_opt_annos ~level ~sep:Space)
         opt_annos
         (pp_list_v ~level:(level + 1) ~sep:Nl)
         stmts (indent level)
@@ -973,54 +1097,40 @@ and pp_syntax_parser_state ~level fmt (value : value) : unit =
         (Printf.sprintf "@pp_syntax_parser_state: expected parser state, got %s"
            (id_of_case_v value))
 
-and pp_syntax_parser_type_decl ~level fmt (value : value) : unit =
+(* Specified identifiers for enum declarations *)
+
+and pp_syntax_spec_id fmt (value : value) : unit =
   match flatten_case_v value with
-  | ( "parserTypeDeclaration",
-      [ []; [ "PARSER" ]; []; [ "(" ]; [ ")" ] ],
-      [ opt_annos; name; opt_tparams; params ] ) ->
-      F.fprintf fmt "%aparser %a%a(%a)"
-        (pp_opt_annos ~level ~sep:Nl)
-        opt_annos pp_case_v name
-        (pp_opt_v ~postfix:"" pp_case_v)
-        opt_tparams
-        (pp_list_v ~level:0 ~sep:Comma)
-        params
-  | "parserTypeDeclaration", _, _ ->
+  | "specifiedIdentifier", [ []; []; [] ], [ name; init ] ->
+      F.fprintf fmt "%a%a" pp_case_v name pp_case_v init
+  | "specifiedIdentifier", _, _ ->
       failwith
-        (F.asprintf
-           "@pp_syntax_parser_type_decl: ill-formed parser type declaration:\n\
-            %a"
-           pp_case_v value)
+        (F.asprintf "@pp_syntax_spec_id: ill-formed specified identifier:\n%a"
+           pp_default_case_v value)
   | _ ->
       failwith
         (Printf.sprintf
-           "@pp_syntax_parser_type_decl: expected parser type declaration, got \
-            %s"
+           "@pp_syntax_spec_id: expected specified identifier, got %s"
            (id_of_case_v value))
 
-and pp_syntax_pckg_type_decl ~level fmt (value : value) : unit =
+(* Struct fields *)
+
+and pp_syntax_struct_field fmt (value : value) : unit =
   match flatten_case_v value with
-  | ( "packageTypeDeclaration",
-      [ []; [ "PACKAGE" ]; []; [ "(" ]; [ ")" ] ],
-      [ opt_annos; name; opt_tparams; params ] ) ->
-      F.fprintf fmt "%apackage %a%a(%a)"
-        (pp_opt_annos ~level ~sep:Nl)
-        opt_annos pp_case_v name
-        (pp_opt_v ~postfix:"" pp_case_v)
-        opt_tparams
-        (pp_list_v ~level:0 ~sep:Comma)
-        params
-  | "packageTypeDeclaration", _, _ ->
+  | "structField", [ []; []; []; [ ";" ] ], [ opt_annos; type_ref; name ] ->
+      F.fprintf fmt "%a%a %a;"
+        (pp_opt_annos ~level:0 ~sep:Space)
+        opt_annos pp_case_v type_ref pp_case_v name
+  | "structField", _, _ ->
       failwith
-        (F.asprintf
-           "@pp_syntax_pckg_type_decl: ill-formed package type declaration:\n%a"
-           pp_case_v value)
+        (F.asprintf "@pp_syntax_struct_field: ill-formed struct field:\n%a"
+           pp_default_case_v value)
   | _ ->
       failwith
-        (Printf.sprintf
-           "@pp_syntax_pckg_type_decl: expected package type declaration, got \
-            %s"
+        (Printf.sprintf "@pp_syntax_struct_field: expected struct field, got %s"
            (id_of_case_v value))
+
+(* Declarations *)
 
 and pp_syntax_decl ~level fmt (value : value) : unit =
   match flatten_case_v value with
@@ -1030,6 +1140,14 @@ and pp_syntax_decl ~level fmt (value : value) : unit =
       F.fprintf fmt "%aconst %a %a%a;"
         (pp_opt_annos ~level ~sep:Nl)
         opt_annos pp_case_v type_ref pp_case_v name pp_case_v init
+  | ( "variableDeclarationWithoutSemicolon",
+      [ []; []; []; []; [] ],
+      [ opt_annos; type_ref; name; opt_init ] ) ->
+      F.fprintf fmt "%a%a %a%a"
+        (pp_opt_annos ~level:0 ~sep:Space)
+        opt_annos pp_case_v type_ref pp_case_v name
+        (pp_opt_v ~postfix:"" pp_case_v)
+        opt_init
   | "variableDeclaration", [ []; [ ";" ] ], [ decl ] ->
       F.fprintf fmt "%a;" pp_case_v decl
   | ( "matchKindDeclaration",
@@ -1096,11 +1214,20 @@ and pp_syntax_decl ~level fmt (value : value) : unit =
         opt_annos pp_case_v name
         (pp_list_v ~level:(level + 1) ~sep:Nl)
         props (indent level)
+  | ( "controlTypeDeclaration",
+      [ []; [ "CONTROL" ]; []; [ "(" ]; [ ")" ] ],
+      [ opt_annos; name; tparams; params ] ) ->
+      F.fprintf fmt "%acontrol %a%a(%a)"
+        (pp_opt_annos ~level ~sep:Nl)
+        opt_annos pp_case_v name
+        (pp_opt_v ~postfix:"" pp_case_v)
+        tparams
+        (pp_list_v ~level:0 ~sep:Comma)
+        params
   | ( "controlDeclaration",
       [ []; []; [ "{" ]; [ "APPLY" ]; [ "}" ] ],
       [ control_type_decl; opt_constructor_params; locals; apply_body ] ) ->
-      F.fprintf fmt "%a%a {\n%a\n%sapply %a\n%s}"
-        (pp_syntax_ctrl_typ_decl ~level)
+      F.fprintf fmt "%a%a {\n%a\n%sapply %a\n%s}" (pp_syntax_decl ~level)
         control_type_decl
         (pp_opt_v ~postfix:"" pp_case_v)
         opt_constructor_params
@@ -1127,18 +1254,36 @@ and pp_syntax_decl ~level fmt (value : value) : unit =
       F.fprintf fmt "%avalue_set<%a>(%a) %a;"
         (pp_opt_annos ~level ~sep:Nl)
         opt_annos pp_case_v type_name pp_case_v size pp_case_v name
+  | ( "parserTypeDeclaration",
+      [ []; [ "PARSER" ]; []; [ "(" ]; [ ")" ] ],
+      [ opt_annos; name; opt_tparams; params ] ) ->
+      F.fprintf fmt "%aparser %a%a(%a)"
+        (pp_opt_annos ~level ~sep:Nl)
+        opt_annos pp_case_v name
+        (pp_opt_v ~postfix:"" pp_case_v)
+        opt_tparams
+        (pp_list_v ~level:0 ~sep:Comma)
+        params
   | ( "parserDeclaration",
       [ []; []; [ "{" ]; []; [ "}" ] ],
       [ decl; params; locals; states ] ) ->
-      F.fprintf fmt "%a%a {\n%a\n%a\n%s}"
-        (pp_syntax_parser_type_decl ~level)
-        decl
+      F.fprintf fmt "%a%a {\n%a\n%a\n%s}" (pp_syntax_decl ~level) decl
         (pp_opt_v ~postfix:"" pp_case_v)
         params
         (pp_list_v ~level:(level + 1) ~sep:Nl)
         locals
         (pp_list_v ~level:(level + 1) ~sep:Nl)
         states (indent level)
+  | ( "packageTypeDeclaration",
+      [ []; [ "PACKAGE" ]; []; [ "(" ]; [ ")" ] ],
+      [ opt_annos; name; opt_tparams; params ] ) ->
+      F.fprintf fmt "%apackage %a%a(%a)"
+        (pp_opt_annos ~level ~sep:Nl)
+        opt_annos pp_case_v name
+        (pp_opt_v ~postfix:"" pp_case_v)
+        opt_tparams
+        (pp_list_v ~level:0 ~sep:Comma)
+        params
   | ( "enumDeclaration",
       [ []; [ "ENUM" ]; [ "{" ]; []; [ "}" ] ],
       [ opt_annos; name; ids; opt_comma ] ) ->
@@ -1210,15 +1355,17 @@ and pp_syntax_decl ~level fmt (value : value) : unit =
   | "typeDeclaration", [ []; [ ";" ] ], [ typedef ] ->
       F.fprintf fmt "%a;" (pp_syntax_decl ~level) typedef
   | "typeDeclaration", [ []; [ ";"; "PHTM_13" ] ], [ parser_type_decl ] ->
-      F.fprintf fmt "%a;" (pp_syntax_parser_type_decl ~level) parser_type_decl
+      F.fprintf fmt "%a;" (pp_syntax_decl ~level) parser_type_decl
   | "typeDeclaration", [ []; [ ";"; "PHTM_14" ] ], [ ctrl_type_decl ] ->
-      F.fprintf fmt "%a;" (pp_syntax_ctrl_typ_decl ~level) ctrl_type_decl
+      F.fprintf fmt "%a;" (pp_syntax_decl ~level) ctrl_type_decl
   | "typeDeclaration", [ []; [ ";"; "PHTM_15" ] ], [ pckg_type_decl ] ->
-      F.fprintf fmt "%a;" (pp_syntax_pckg_type_decl ~level) pckg_type_decl
+      F.fprintf fmt "%a;" (pp_syntax_decl ~level) pckg_type_decl
   | _ ->
       failwith
         (Printf.sprintf "@pp_syntax_decl: expected declaration, got %s"
            (id_of_case_v value))
+
+(* Annotations *)
 
 and pp_syntax_anno_token fmt (value : value) : unit =
   match flatten_case_v value with
@@ -1319,8 +1466,15 @@ and pp_syntax_anno_token fmt (value : value) : unit =
            "@pp_syntax_anno_token: expected annotation token, got %s"
            (id_of_case_v value))
 
-and pp_syntax_struct_anno_body fmt (value : value) : unit =
+and pp_syntax_anno_body fmt (value : value) : unit =
   match flatten_case_v value with
+  | "simpleAnnotation", [ [ "(" ]; [ ")" ] ], [ body ] ->
+      F.fprintf fmt "(%a)" (pp_list_v ~level:0 ~sep:Space) body
+  | "simpleAnnotation", _, _ ->
+      failwith
+        (F.asprintf
+           "@pp_syntax_anno_body: ill-formed simple annotation body:\n%a"
+           pp_case_v value)
   | "structuredAnnotationBody", [ []; []; [] ], [ exprs; opt_comma ] ->
       F.fprintf fmt "%a%a"
         (pp_list_v ~level:0 ~sep:Comma)
@@ -1336,14 +1490,12 @@ and pp_syntax_struct_anno_body fmt (value : value) : unit =
   | "structuredAnnotationBody", _, _ ->
       failwith
         (F.asprintf
-           "@pp_syntax_struct_anno_body: ill-formed structured annotation body:\n\
-            %a"
+           "@pp_syntax_anno_body: ill-formed structured annotation body:\n%a"
            pp_case_v value)
   | _ ->
       failwith
         (Printf.sprintf
-           "@pp_syntax_struct_anno_body: expected structured annotation body, \
-            got %s"
+           "@pp_syntax_anno_body: expected structured annotation body, got %s"
            (id_of_case_v value))
 
 and pp_syntax_anno fmt (value : value) : unit =
@@ -1352,13 +1504,13 @@ and pp_syntax_anno fmt (value : value) : unit =
       F.fprintf fmt "@%a" pp_case_v name
   | "annotation", [ [ "@" ]; [ "(" ]; [ ")" ] ], [ name; body ] ->
       F.fprintf fmt "@%a(%a)" pp_case_v name
-        (pp_list_v ~level:0 ~sep:SpaceSep)
+        (pp_list_v ~level:0 ~sep:Space)
         body
   | "annotation", [ [ "@" ]; [ "[" ]; [ "]" ] ], [ name; body ] ->
       F.fprintf fmt "@%a[%a]" pp_case_v name pp_case_v body
   | "annotation", [ [ "PRAGMA" ]; []; [ "PRAGMA_END" ] ], [ name; body ] ->
       F.fprintf fmt "@pragma %a %a" pp_case_v name
-        (pp_list_v ~level:0 ~sep:SpaceSep)
+        (pp_list_v ~level:0 ~sep:Space)
         body
   | "annotation", _, _ ->
       failwith
@@ -1369,68 +1521,35 @@ and pp_syntax_anno fmt (value : value) : unit =
         (Printf.sprintf "@pp_syntax_anno: expected annotation, got %s"
            (id_of_case_v value))
 
-and pp_opt_annos ?(level = 0) ~sep fmt (value : value) : unit =
+and pp_opt_annos ?(level = 0) ~(sep : sep) fmt (value : value) : unit =
   let postfix = if is_nl sep then F.sprintf "\n%s" (indent level) else " " in
   pp_opt_v ~postfix (pp_list_v ~level ~sep) fmt value
 
-and pp_case_v' fmt (value : value) : unit =
-  match flatten_case_v value with
-  (* Misc *)
-  | "trailingComma", [ [ ","; "PHTM_0" ] ], [] -> F.fprintf fmt ","
-  | "const", [ [ "CONST" ] ], [] -> F.fprintf fmt "const"
-  (* Numbers *)
-  | "number", [ []; [ "PHTM_1" ] ], [ value_int ] ->
-      F.fprintf fmt "%a" pp_value value_int
-  | "number", [ []; [ "S" ]; [] ], [ value_width; value_int ] ->
-      F.fprintf fmt "%as%a" pp_value value_width pp_value value_int
-  | "number", [ []; [ "W" ]; [] ], [ value_width; value_int ] ->
-      F.fprintf fmt "%aw%a" pp_value value_width pp_value value_int
-  (* Strings *)
-  | "stringLiteral", [ []; [ "PHTM_2" ] ], [ value_text ] ->
-      F.fprintf fmt "%a" (pp_text_v ~escaped:true) value_text
-  (* Names *)
-  | "dotPrefix", [ [ "." ] ], [] -> F.fprintf fmt "."
-  (* Type references *)
-  | "typeOrVoid", [ [ "VOID" ] ], [] -> F.fprintf fmt "void"
-  (* Key value pair *)
-  | "kvPair", [ []; [ "=" ]; [] ], [ key; value ] ->
-      F.fprintf fmt "%a = %a" pp_case_v key pp_case_v value
-  (* Declarations *)
-  | ( "variableDeclarationWithoutSemicolon",
-      [ []; []; []; []; [] ],
-      [ opt_annos; type_ref; name; opt_init ] ) ->
-      F.fprintf fmt "%a%a %a%a"
-        (pp_opt_annos ~level:0 ~sep:SpaceSep)
-        opt_annos pp_case_v type_ref pp_case_v name
-        (pp_opt_v ~postfix:"" pp_case_v)
-        opt_init
-  | "specifiedIdentifier", [ []; []; [] ], [ name; init ] ->
-      F.fprintf fmt "%a%a" pp_case_v name pp_case_v init
-  | "structField", [ []; []; []; [ ";" ] ], [ opt_annos; type_ref; name ] ->
-      F.fprintf fmt "%a%a %a;"
-        (pp_opt_annos ~level:0 ~sep:SpaceSep)
-        opt_annos pp_case_v type_ref pp_case_v name
-  (* Annotations *)
-  | "simpleAnnotation", [ [ "(" ]; [ ")" ] ], [ body ] ->
-      F.fprintf fmt "(%a)" (pp_list_v ~level:0 ~sep:SpaceSep) body
-  | _ -> pp_default_case_v fmt value
+(* CaseV *)
 
 and pp_case_v fmt (value : value) : unit =
   match id_of_case_v value with
-  | "constantDeclaration" | "variableDeclaration" | "errorDeclaration"
-  | "matchKindDeclaration" | "externDeclaration" | "instantiation"
-  | "functionDeclaration" | "actionDeclaration" | "parserDeclaration"
+  | "constantDeclaration" | "variableDeclarationWithoutSemicolon"
+  | "variableDeclaration" | "errorDeclaration" | "matchKindDeclaration"
+  | "externDeclaration" | "instantiation" | "functionDeclaration"
+  | "actionDeclaration" | "parserDeclaration" | "controlTypeDeclaration"
   | "controlDeclaration" | "valueSetDeclaration" | "headerTypeDeclaration"
-  | "headerUnionDeclaration" | "structTypeDeclaration" | "enumDeclaration"
-  | "typedefDeclaration" | "typeDeclaration" ->
+  | "headerUnionDeclaration" | "structTypeDeclaration" | "parserTypeDeclaration"
+  | "enumDeclaration" | "typedefDeclaration" | "typeDeclaration"
+  | "packageTypeDeclaration" ->
       pp_syntax_decl ~level:0 fmt value
-  | "nonTypeName" | "name" | "prefixedNonTypeName" | "prefixedType" ->
+  | "trailingComma" -> pp_syntax_comma fmt value
+  | "const" -> pp_syntax_const fmt value
+  | "number" -> pp_syntax_num fmt value
+  | "stringLiteral" -> pp_syntax_str fmt value
+  | "dotPrefix" | "nonTypeName" | "name" | "prefixedNonTypeName"
+  | "prefixedType" ->
       pp_syntax_name fmt value
   | "typeIdentifier" -> pp_syntax_tid fmt value
   | "identifier" -> pp_syntax_id fmt value
   | "direction" -> pp_syntax_dir fmt value
   | "baseType" | "specializedType" | "headerStackType" | "listType"
-  | "tupleType" ->
+  | "tupleType" | "typeOrVoid" ->
       pp_syntax_type fmt value
   | "typeParameters" -> pp_syntax_tparams fmt value
   | "parameter" | "constructorParameters" -> pp_syntax_params fmt value
@@ -1439,6 +1558,7 @@ and pp_case_v fmt (value : value) : unit =
   | "simpleKeysetExpression" | "reducedSimpleKeysetExpression"
   | "tupleKeysetExpression" ->
       pp_syntax_keyset_expr fmt value
+  | "kvPair" -> pp_syntax_kvpair fmt value
   | "realTypeArg" | "typeArg" -> pp_syntax_targ fmt value
   | "argument" -> pp_syntax_arg fmt value
   | "lvalue" -> pp_syntax_lvalue fmt value
@@ -1459,16 +1579,16 @@ and pp_case_v fmt (value : value) : unit =
   | "entryPriority" -> pp_syntax_entry_prio fmt value
   | "entry" -> pp_syntax_entry fmt value
   | "tableProperty" -> pp_syntax_table_prop ~level:0 fmt value
-  | "controlTypeDeclaration" -> pp_syntax_ctrl_typ_decl ~level:0 fmt value
   | "selectCase" -> pp_syntax_select_case fmt value
   | "selectExpression" -> pp_syntax_select_expr ~level:0 fmt value
   | "stateExpression" -> pp_syntax_state_expr ~level:0 fmt value
   | "transitionStatement" -> pp_syntax_trans_stmt ~level:0 fmt value
   | "parserBlockStatement" -> pp_syntax_parser_stmt ~level:0 fmt value
   | "parserState" -> pp_syntax_parser_state ~level:0 fmt value
-  | "parserTypeDeclaration" -> pp_syntax_parser_type_decl ~level:0 fmt value
-  | "packageTypeDeclaration" -> pp_syntax_pckg_type_decl ~level:0 fmt value
+  | "specifiedIdentifier" -> pp_syntax_spec_id fmt value
+  | "structField" -> pp_syntax_struct_field fmt value
   | "annotationToken" -> pp_syntax_anno_token fmt value
-  | "structuredAnnotationBody" -> pp_syntax_struct_anno_body fmt value
+  | "simpleAnnotation" | "structuredAnnotationBody" ->
+      pp_syntax_anno_body fmt value
   | "annotation" -> pp_syntax_anno fmt value
-  | _ -> pp_case_v' fmt value
+  | _ -> pp_default_case_v fmt value

--- a/p4spec/lib/parsing/pp.ml
+++ b/p4spec/lib/parsing/pp.ml
@@ -50,7 +50,7 @@ and pp_value fmt (value : value) : unit =
   match value.it with
   | BoolV b -> F.fprintf fmt "%b" b
   | NumV n -> F.fprintf fmt "%a" pp_num n
-  | TextV _ -> pp_text_v fmt value
+  | TextV _ -> pp_text_v ~escaped:false fmt value
   | StructV _ -> failwith "not implemented"
   | CaseV _ -> pp_case_v fmt value
   | TupleV values ->
@@ -61,9 +61,10 @@ and pp_value fmt (value : value) : unit =
   | ListV _ -> pp_list_v ~sep:Nl fmt value
   | _ -> failwith "@pp_value: TODO"
 
-and pp_text_v fmt (value : value) : unit =
+and pp_text_v ~escaped fmt (value : value) : unit =
   match value.it with
-  | TextV text -> F.fprintf fmt "%s" text
+  | TextV text ->
+      if escaped then F.fprintf fmt "%S" text else F.fprintf fmt "%s" text
   | _ -> failwith "@pp_text_v: expected TextV value"
 
 and pp_opt_v ?(postfix = "") pp_v fmt (value : value) : unit =
@@ -113,7 +114,8 @@ and pp_list_v ?(level = 0) ~sep fmt (value : value) : unit =
 
 and pp_syntax_id fmt (value : value) : unit =
   match flatten_case_v value with
-  | "identifier", [ [ "$" ]; [] ], [ value_text ] -> pp_text_v fmt value_text
+  | "identifier", [ [ "$" ]; [] ], [ value_text ] ->
+      pp_text_v ~escaped:false fmt value_text
   | "identifier", _, _ ->
       failwith
         (F.asprintf "@pp_syntax_id: ill-formed identifier:\n%a"
@@ -126,7 +128,7 @@ and pp_syntax_id fmt (value : value) : unit =
 and pp_syntax_tid fmt (value : value) : unit =
   match flatten_case_v value with
   | "typeIdentifier", [ [ "@" ]; [] ], [ value_text ] ->
-      pp_text_v fmt value_text
+      pp_text_v ~escaped:false fmt value_text
   | "typeIdentifier", _, _ ->
       failwith
         (F.asprintf "@pp_syntax_tid: ill-formed typeIdentifier:\n%a"
@@ -289,7 +291,7 @@ and pp_syntax_nb_expr fmt (value : value) : unit =
   | "nonBraceExpression", [ [ "ERROR"; "." ]; [] ], [ member ] ->
       F.fprintf fmt "error.%a" pp_case_v member
   | "nonBraceExpression", [ []; [ "." ]; [ "PHTM_5" ] ], [ expr; member ] ->
-      F.fprintf fmt "%a.%a" pp_case_v expr pp_case_v member
+      F.fprintf fmt "(%a).%a" pp_case_v expr pp_case_v member
   | "nonBraceExpression", [ []; [ binop ]; [] ], [ arg1; arg2 ]
     when is_binary_op binop ->
       F.fprintf fmt "(%a) %s (%a)" pp_case_v arg1 binop pp_case_v arg2
@@ -337,9 +339,9 @@ and pp_syntax_expr fmt (value : value) : unit =
   | "expression", [ []; []; [] ], [ dot; name ] ->
       F.fprintf fmt "%a%a" pp_case_v dot pp_case_v name
   | "expression", [ []; [ "[" ]; [ "]" ] ], [ array; index ] ->
-      F.fprintf fmt "%a[%a]" pp_case_v array pp_case_v index
+      F.fprintf fmt "(%a)[%a]" pp_case_v array pp_case_v index
   | "expression", [ []; [ "[" ]; [ ":" ]; [ "]" ] ], [ bits; hi; lo ] ->
-      F.fprintf fmt "%a[%a:%a]" pp_case_v bits pp_case_v hi pp_case_v lo
+      F.fprintf fmt "(%a)[%a:%a]" pp_case_v bits pp_case_v hi pp_case_v lo
   | "expression", [ [ "{" ]; []; [ "}" ] ], [ exprs; comma ] ->
       F.fprintf fmt "{ %a%a }"
         (pp_list_v ~level:0 ~sep:Comma)
@@ -374,7 +376,7 @@ and pp_syntax_expr fmt (value : value) : unit =
   | "expression", [ [ "ERROR"; "." ]; [] ], [ member ] ->
       F.fprintf fmt "error.%a" pp_case_v member
   | "expression", [ []; [ "." ]; [ "PHTM_5" ] ], [ expr; member ] ->
-      F.fprintf fmt "%a.%a" pp_case_v expr pp_case_v member
+      F.fprintf fmt "(%a).%a" pp_case_v expr pp_case_v member
   | "expression", [ []; [ binop ]; [] ], [ arg1; arg2 ] when is_binary_op binop
     ->
       F.fprintf fmt "(%a) %s (%a)" pp_case_v arg1 binop pp_case_v arg2
@@ -1385,7 +1387,7 @@ and pp_case_v' fmt (value : value) : unit =
       F.fprintf fmt "%aw%a" pp_value value_width pp_value value_int
   (* Strings *)
   | "stringLiteral", [ []; [ "PHTM_2" ] ], [ value_text ] ->
-      F.fprintf fmt "\"%a\"" pp_text_v value_text
+      F.fprintf fmt "%a" (pp_text_v ~escaped:true) value_text
   (* Names *)
   | "dotPrefix", [ [ "." ] ], [] -> F.fprintf fmt "."
   (* Type references *)

--- a/p4spec/lib/parsing/pp.ml
+++ b/p4spec/lib/parsing/pp.ml
@@ -233,9 +233,132 @@ and pp_syntax_params fmt (value : value) : unit =
         (Printf.sprintf "@pp_syntax_params: expected parameter, got %s"
            (id_of_case_v value))
 
-and pp_syntax_expr _fmt (value : value) : unit =
+and pp_syntax_nb_expr fmt (value : value) : unit =
+  let is_binary_op = function
+    | "*" | "/" | "%" | "+" | "|+|" | "-" | "|-|" | "<<" | ">>" | "<=" | ">="
+    | "<" | ">" | "!=" | "==" | "&" | "^" | "|" | "++" | "&&" | "||" ->
+        true
+    | _ -> false
+  in
   match flatten_case_v value with
-  | _ -> failwith "@pp_syntax_expr: not yet implemented"
+  | "nonBraceExpression", [ [ "TRUE" ] ], [] -> F.fprintf fmt "true"
+  | "nonBraceExpression", [ [ "FALSE" ] ], [] -> F.fprintf fmt "false"
+  | "nonBraceExpression", [ [ "THIS" ] ], [] -> F.fprintf fmt "this"
+  | "nonBraceExpression", [ []; [ "[" ]; [ "]" ] ], [ array; index ] ->
+      F.fprintf fmt "(%a)[%a]" pp_case_v array pp_case_v index
+  | "nonBraceExpression", [ []; [ "[" ]; [ ":" ]; [ "]" ] ], [ bits; hi; lo ] ->
+      F.fprintf fmt "(%a)[%a:%a]" pp_case_v bits pp_case_v hi pp_case_v lo
+  | "nonBraceExpression", [ [ "!" ]; [] ], [ arg ] ->
+      F.fprintf fmt "!(%a)" pp_case_v arg
+  | "nonBraceExpression", [ [ "~" ]; [] ], [ arg ] ->
+      F.fprintf fmt "~(%a)" pp_case_v arg
+  | "nonBraceExpression", [ [ "-" ]; [] ], [ arg ] ->
+      F.fprintf fmt "-(%a)" pp_case_v arg
+  | "nonBraceExpression", [ [ "+" ]; [] ], [ arg ] ->
+      F.fprintf fmt "+(%a)" pp_case_v arg
+  | "nonBraceExpression", [ []; [ "." ]; [] ], [ typ; member ] ->
+      F.fprintf fmt "(%a).(%a)" pp_case_v typ pp_case_v member
+  | "nonBraceExpression", [ [ "ERROR"; "." ]; [] ], [ member ] ->
+      F.fprintf fmt "error.(%a)" pp_case_v member
+  | "nonBraceExpression", [ []; [ "." ]; [ "PHTM_5" ] ], [ expr; member ] ->
+      F.fprintf fmt "(%a).(%a)" pp_case_v expr pp_case_v member
+  | "nonBraceExpression", [ []; [ binop ]; [] ], [ arg1; arg2 ]
+    when is_binary_op binop ->
+      F.fprintf fmt "(%a) %s (%a)" pp_case_v arg1 binop pp_case_v arg2
+  | ( "nonBraceExpression",
+      [ []; [ "?" ]; [ ":" ]; [] ],
+      [ cond; true_expr; false_expr ] ) ->
+      F.fprintf fmt "(%a) ? (%a) : (%a)" pp_case_v cond pp_case_v true_expr
+        pp_case_v false_expr
+  | ( "nonBraceExpression",
+      [ []; [ "<" ]; [ ">"; "(" ]; [ ")" ] ],
+      [ func; type_args; args ] ) ->
+      F.fprintf fmt "(%a)<%a>(%a)" pp_case_v func (pp_list_v ~sep:Comma)
+        type_args (pp_list_v ~sep:Comma) args
+  | "nonBraceExpression", [ []; [ "(" ]; [ ")" ] ], [ func; args ] ->
+      F.fprintf fmt "(%a)(%a)" pp_case_v func (pp_list_v ~sep:Comma) args
+  | "nonBraceExpression", [ []; [ "(" ]; [ ")"; "PHTM_6" ] ], [ typ; args ] ->
+      F.fprintf fmt "(%a)(%a)" pp_case_v typ (pp_list_v ~sep:Comma) args
+  | "nonBraceExpression", [ [ "(" ]; [ ")" ]; [] ], [ typ; expr ] ->
+      F.fprintf fmt "(%a)(%a)" pp_case_v typ pp_case_v expr
+  | "nonBraceExpression", _, _ ->
+      failwith
+        (F.asprintf "@pp_syntax_nb_expr: ill-formed non-brace expression:\n%a"
+           pp_case_v value)
+  | _ ->
+      failwith
+        (Printf.sprintf
+           "@pp_syntax_nb_expr: expected non-brace expression, got %s"
+           (id_of_case_v value))
+
+and pp_syntax_expr fmt (value : value) : unit =
+  let is_binary_op = function
+    | "*" | "/" | "%" | "+" | "|+|" | "-" | "|-|" | "<<" | ">>" | "<=" | ">="
+    | "<" | ">" | "!=" | "==" | "&" | "^" | "|" | "++" | "&&" | "||" ->
+        true
+    | _ -> false
+  in
+  match flatten_case_v value with
+  | "expression", [ [ "..." ] ], [] -> F.fprintf fmt "..."
+  | "expression", [ [ "TRUE" ] ], [] -> F.fprintf fmt "true"
+  | "expression", [ [ "FALSE" ] ], [] -> F.fprintf fmt "false"
+  | "expression", [ [ "THIS" ] ], [] -> F.fprintf fmt "this"
+  | "expression", [ []; []; [] ], [ dot; name ] ->
+      F.fprintf fmt "%a%a" pp_case_v dot pp_case_v name
+  | "expression", [ []; [ "[" ]; [ "]" ] ], [ array; index ] ->
+      F.fprintf fmt "(%a)[%a]" pp_case_v array pp_case_v index
+  | "expression", [ []; [ "[" ]; [ ":" ]; [ "]" ] ], [ bits; hi; lo ] ->
+      F.fprintf fmt "(%a)[%a:%a]" pp_case_v bits pp_case_v hi pp_case_v lo
+  | "expression", [ [ "{" ]; []; [ "}" ] ], [ exprs; comma ] ->
+      F.fprintf fmt "{ %a%a }" (pp_list_v ~sep:Comma) exprs
+        (pp_opt_v ~postfix:"") comma
+  | "expression", [ [ "INVALID" ] ], [] -> F.fprintf fmt "{#}"
+  | "expression", [ [ "{" ]; []; [ "}"; "PHTM_7" ] ], [ kvs; comma ] ->
+      F.fprintf fmt "{ %a%a }" (pp_list_v ~sep:Comma) kvs (pp_opt_v ~postfix:"")
+        comma
+  | "expression", [ [ "{" ]; [ ","; "..." ]; [ "}" ] ], [ kvs; comma ] ->
+      F.fprintf fmt "{ %a, ...%a }" (pp_list_v ~sep:Comma) kvs
+        (pp_opt_v ~postfix:"") comma
+  | "expression", [ [ "!" ]; [] ], [ arg ] ->
+      F.fprintf fmt "!(%a)" pp_case_v arg
+  | "expression", [ [ "~" ]; [] ], [ arg ] ->
+      F.fprintf fmt "~(%a)" pp_case_v arg
+  | "expression", [ [ "-" ]; [] ], [ arg ] ->
+      F.fprintf fmt "-(%a)" pp_case_v arg
+  | "expression", [ [ "+" ]; [] ], [ arg ] ->
+      F.fprintf fmt "+(%a)" pp_case_v arg
+  | "expression", [ [ "(" ]; [ ")" ]; [] ], [ typ; expr ] ->
+      F.fprintf fmt "(%a)(%a)" pp_case_v typ pp_case_v expr
+  | "expression", [ []; [ "." ]; [] ], [ typ; name ] ->
+      F.fprintf fmt "(%a).(%a)" pp_case_v typ pp_case_v name
+  | "expression", [ [ "ERROR"; "." ]; [] ], [ member ] ->
+      F.fprintf fmt "error.(%a)" pp_case_v member
+  | "expression", [ []; [ "." ]; [ "PHTM_5" ] ], [ expr; member ] ->
+      F.fprintf fmt "(%a).(%a)" pp_case_v expr pp_case_v member
+  | "expression", [ []; [ binop ]; [] ], [ arg1; arg2 ] when is_binary_op binop
+    ->
+      F.fprintf fmt "(%a) %s (%a)" pp_case_v arg1 binop pp_case_v arg2
+  | "expression", [ []; [ "?" ]; [ ":" ]; [] ], [ cond; true_expr; false_expr ]
+    ->
+      F.fprintf fmt "(%a) ? (%a) : (%a)" pp_case_v cond pp_case_v true_expr
+        pp_case_v false_expr
+  | ( "expression",
+      [ []; [ "<" ]; [ ">"; "(" ]; [ ")" ] ],
+      [ func; type_args; args ] ) ->
+      F.fprintf fmt "(%a)<%a>(%a)" pp_case_v func (pp_list_v ~sep:Comma)
+        type_args (pp_list_v ~sep:Comma) args
+  | "expression", [ []; [ "(" ]; [ ")" ] ], [ func; args ] ->
+      F.fprintf fmt "(%a)(%a)" pp_case_v func (pp_list_v ~sep:Comma) args
+  | "expression", [ []; [ "(" ]; [ ")"; "PHTM_6" ] ], [ typ; args ] ->
+      F.fprintf fmt "(%a)(%a)" pp_case_v typ (pp_list_v ~sep:Comma) args
+  | "expression", _, _ ->
+      failwith
+        (F.asprintf "@pp_syntax_expr: ill-formed expression:\n%a" pp_case_v
+           value)
+  | _ ->
+      failwith
+        (Printf.sprintf "@pp_syntax_nb_expr: expected expression, got %s"
+           (id_of_case_v value))
 
 and pp_syntax_type_arg _fmt (value : value) : unit =
   match flatten_case_v value with
@@ -380,4 +503,6 @@ and pp_case_v fmt (value : value) : unit =
       pp_syntax_type fmt value
   | "typeParameters" -> pp_syntax_tparams fmt value
   | "parameter" | "constructorParameters" -> pp_syntax_params fmt value
+  | "nonBraceExpression" -> pp_syntax_nb_expr fmt value
+  | "expression" -> pp_syntax_expr fmt value
   | _ -> pp_case_v' fmt value

--- a/p4spec/lib/parsing/pp.ml
+++ b/p4spec/lib/parsing/pp.ml
@@ -82,8 +82,9 @@ and pp_list_v ?(level = 0) ~sep fmt (value : value) : unit =
   in
   match id_of_list_v value with
   | "identifier" | "typeParameterList" | "parameter" | "expression" | "kvPair"
-  | "simpleKeysetExpression" | "realTypeArg" | "typeArg" | "argument" ->
-      pp_list pp_case_v ~sep fmt values
+  | "simpleKeysetExpression" | "realTypeArg" | "typeArg" | "argument"
+  | "keyElement" | "action" | "entry" | "annotation" | "simpleAnnotation" ->
+      pp_list ~level pp_case_v ~sep fmt values
   | "switchCase" -> pp_list ~level (pp_syntax_stmt' ~level) ~sep fmt values
   | "declOrAssignmentOrMethodCallStatement" ->
       pp_list pp_syntax_decl_or_assign_or_call_stmt ~sep fmt values
@@ -92,7 +93,10 @@ and pp_list_v ?(level = 0) ~sep fmt (value : value) : unit =
   | "statementOrDeclaration" ->
       pp_list ~level (pp_syntax_stat_or_decl ~level) ~sep fmt values
   | "methodPrototype" -> pp_list ~level (pp_syntax_mthd ~level) ~sep fmt values
-  | "objDeclaration" -> pp_list ~level (pp_syntax_decl ~level) ~sep fmt values
+  | "objDeclaration" | "controlLocalDeclaration" ->
+      pp_list ~level (pp_syntax_decl ~level) ~sep fmt values
+  | "tableProperty" ->
+      pp_list ~level (pp_syntax_table_prop ~level) ~sep fmt values
   | "declaration" when List.compare_length_with values 0 = 0 ->
       F.fprintf fmt ";"
   | "declaration" -> pp_list ~level (pp_syntax_decl ~level) ~sep fmt values
@@ -146,9 +150,9 @@ and pp_syntax_name fmt (value : value) : unit =
 
 and pp_syntax_dir fmt (value : value) : unit =
   match flatten_case_v value with
-  | "direction", [ [ "IN" ] ], [] -> F.fprintf fmt "in"
-  | "direction", [ [ "OUT" ] ], [] -> F.fprintf fmt "out"
-  | "direction", [ [ "INOUT" ] ], [] -> F.fprintf fmt "inout"
+  | "direction", [ [ "IN" ] ], [] -> F.fprintf fmt "in "
+  | "direction", [ [ "OUT" ] ], [] -> F.fprintf fmt "out "
+  | "direction", [ [ "INOUT" ] ], [] -> F.fprintf fmt "inout "
   | "direction", [ [ "NONE" ] ], [] -> F.fprintf fmt ""
   | "direction", _, _ ->
       failwith
@@ -230,13 +234,13 @@ and pp_syntax_tparams fmt (value : value) : unit =
 and pp_syntax_params fmt (value : value) : unit =
   match flatten_case_v value with
   | "parameter", [ []; []; []; []; [] ], [ opt_annos; dir; type_ref; name ] ->
-      F.fprintf fmt "%a%a %a %a"
+      F.fprintf fmt "%a%a%a %a"
         (pp_opt_annos ~level:0 ~sep:SpaceSep)
         opt_annos pp_case_v dir pp_case_v type_ref pp_case_v name
   | ( "parameter",
       [ []; []; []; []; []; [] ],
       [ opt_annos; dir; type_ref; name; init ] ) ->
-      F.fprintf fmt "%a%a %a %a%a"
+      F.fprintf fmt "%a%a%a %a%a"
         (pp_opt_annos ~level:0 ~sep:SpaceSep)
         opt_annos pp_case_v dir pp_case_v type_ref pp_case_v name pp_case_v init
   | "parameter", _, _ ->
@@ -520,14 +524,14 @@ and pp_syntax_stmt' ~level fmt (value : value) : unit =
   | ( "assignmentOrMethodCallStatementWithoutSemicolon",
       [ []; [ "(" ]; [ ")" ] ],
       [ func; args ] ) ->
-      F.fprintf fmt "%a(%a)" pp_case_v func (pp_list_v ~level ~sep:Comma) args
+      F.fprintf fmt "%a(%a)" pp_case_v func (pp_list_v ~level:0 ~sep:Comma) args
   | ( "assignmentOrMethodCallStatementWithoutSemicolon",
       [ []; [ "<" ]; [ ">"; "(" ]; [ ")" ] ],
       [ func; targs; args ] ) ->
       F.fprintf fmt "%a<%a>(%a)" pp_case_v func
-        (pp_list_v ~level ~sep:Comma)
+        (pp_list_v ~level:0 ~sep:Comma)
         targs
-        (pp_list_v ~level ~sep:Comma)
+        (pp_list_v ~level:0 ~sep:Comma)
         args
   | ( "assignmentOrMethodCallStatementWithoutSemicolon",
       [ []; [ assign_op ]; [] ],
@@ -558,7 +562,7 @@ and pp_syntax_stmt ~level fmt (value : value) : unit =
       [ []; [ "."; "APPLY"; "(" ]; [ ")"; ";" ] ],
       [ named_type; args ] ) ->
       F.fprintf fmt "%a.apply(%a);" pp_case_v named_type
-        (pp_list_v ~level ~sep:Comma)
+        (pp_list_v ~level:0 ~sep:Comma)
         args
   | "conditionalStatement", [ [ "IF"; "(" ]; [ ")" ]; [] ], [ cond; tru ] ->
       F.fprintf fmt "if (%a) %a" pp_case_v cond (pp_syntax_stmt ~level) tru
@@ -580,16 +584,14 @@ and pp_syntax_stmt ~level fmt (value : value) : unit =
       [ [ "SWITCH"; "(" ]; [ ")"; "{" ]; [ "}" ] ],
       [ expr; cases ] ) ->
       F.fprintf fmt "switch (%a) {\n%a\n%s}" pp_case_v expr
-        (pp_list_v ~level ~sep:Nl) cases (indent level)
+        (pp_list_v ~level:(level + 1) ~sep:Nl)
+        cases (indent level)
   | ( "forStatement",
       [ []; [ "FOR"; "(" ]; [ ";" ]; [ ";" ]; [ ")" ]; [] ],
       [ opt_annos; init; cond; update; body ] ) ->
-      let pp_opt_annos =
-        pp_opt_v
-          ~postfix:(F.sprintf "\n%s" (indent level))
-          (pp_list_v ~level ~sep:Nl)
-      in
-      F.fprintf fmt "%afor (%a; %a; %a) %a" pp_opt_annos opt_annos
+      F.fprintf fmt "%afor (%a; %a; %a) %a"
+        (pp_opt_annos ~level ~sep:Nl)
+        opt_annos
         (pp_list_v ~level:0 ~sep:Comma)
         init pp_case_v cond
         (pp_list_v ~level:0 ~sep:Comma)
@@ -677,8 +679,9 @@ and pp_syntax_decl_or_assign_or_call_stmt fmt (value : value) : unit =
 and pp_syntax_obj_init ~level fmt (value : value) : unit =
   match flatten_case_v value with
   | "objInitializer", [ [ "="; "{" ]; [ "}" ] ], [ decls ] ->
-      F.fprintf fmt " = {\n%a\n%s}" (pp_list_v ~level ~sep:Nl) decls
-        (indent level)
+      F.fprintf fmt " = {\n%a\n%s}"
+        (pp_list_v ~level:(level + 1) ~sep:Nl)
+        decls (indent level)
   | "objInitializer", _, _ ->
       failwith
         (F.asprintf "@pp_syntax_obj_init: ill-formed object initializer:\n%a"
@@ -687,6 +690,153 @@ and pp_syntax_obj_init ~level fmt (value : value) : unit =
       failwith
         (Printf.sprintf
            "@pp_syntax_obj_init: expected object initializer, got %s"
+           (id_of_case_v value))
+
+and pp_syntax_key fmt (value : value) : unit =
+  match flatten_case_v value with
+  | "keyElement", [ []; [ ":" ]; []; [ ";" ] ], [ key; match_kind; opt_annos ]
+    ->
+      let space = match opt_annos.it with OptV (Some _) -> " " | _ -> "" in
+      F.fprintf fmt "%a : %a%s%a;" pp_case_v key pp_case_v match_kind space
+        (pp_opt_annos ~level:0 ~sep:SpaceSep)
+        opt_annos
+  | "keyElement", _, _ ->
+      failwith
+        (F.asprintf "@pp_syntax_key: ill-formed key element:\n%a" pp_case_v
+           value)
+  | _ ->
+      failwith
+        (Printf.sprintf "@pp_syntax_key: expected key element, got %s"
+           (id_of_case_v value))
+
+and pp_syntax_action_ref fmt (value : value) : unit =
+  match flatten_case_v value with
+  | "actionRef", [ []; [ "(" ]; [ ")" ] ], [ name; args ] ->
+      F.fprintf fmt "%a(%a)" pp_case_v name (pp_list_v ~level:0 ~sep:Comma) args
+  | "actionRef", _, _ ->
+      failwith
+        (F.asprintf "@pp_syntax_action_ref: ill-formed action ref:\n%a"
+           pp_case_v value)
+  | _ ->
+      failwith
+        (Printf.sprintf "@pp_syntax_action_ref: expected action ref, got %s"
+           (id_of_case_v value))
+
+and pp_syntax_action fmt (value : value) : unit =
+  match flatten_case_v value with
+  | "action", [ []; []; [ ";" ] ], [ opt_annos; action_ref ] ->
+      F.fprintf fmt "%a%a;"
+        (pp_opt_annos ~level:0 ~sep:SpaceSep)
+        opt_annos pp_case_v action_ref
+  | "action", _, _ ->
+      failwith
+        (F.asprintf "@pp_syntax_action: ill-formed action:\n%a" pp_case_v value)
+  | _ ->
+      failwith
+        (Printf.sprintf "@pp_syntax_action: expected action, got %s"
+           (id_of_case_v value))
+
+and pp_syntax_entry_prio fmt (value : value) : unit =
+  match flatten_case_v value with
+  | "entryPriority", [ [ "PRIORITY"; "=" ]; [ ":" ] ], [ num ] ->
+      F.fprintf fmt "priority = %a:" pp_case_v num
+  | "entryPriority", [ [ "PRIORITY"; "="; "(" ]; [ ")"; ":" ] ], [ expr ] ->
+      F.fprintf fmt "priority = (%a):" pp_case_v expr
+  | "entryPriority", _, _ ->
+      failwith
+        (F.asprintf "@pp_syntax_entry_prio: ill-formed entry priority:\n%a"
+           pp_case_v value)
+  | _ ->
+      failwith
+        (Printf.sprintf "@pp_syntax_entry_prio: expected entry priority, got %s"
+           (id_of_case_v value))
+
+and pp_syntax_entry fmt (value : value) : unit =
+  match flatten_case_v value with
+  | ( "entry",
+      [ []; []; []; [ ":" ]; []; [ ";" ] ],
+      [ opt_const; prio; keyset; action; opt_annos ] ) ->
+      let space = match opt_annos.it with OptV (Some _) -> " " | _ -> "" in
+      F.fprintf fmt "%a%a %a : %a%s%a;"
+        (pp_opt_v ~postfix:" " pp_case_v)
+        opt_const pp_case_v prio pp_case_v keyset pp_case_v action space
+        (pp_opt_annos ~level:0 ~sep:SpaceSep)
+        opt_annos
+  | ( "entry",
+      [ []; []; [ ":" ]; []; [ ";" ] ],
+      [ opt_const; keyset; action; opt_annos ] ) ->
+      let space = match opt_annos.it with OptV (Some _) -> " " | _ -> "" in
+      F.fprintf fmt "%a%a : %a%s%a;"
+        (pp_opt_v ~postfix:" " pp_case_v)
+        opt_const pp_case_v keyset pp_case_v action space
+        (pp_opt_annos ~level:0 ~sep:SpaceSep)
+        opt_annos
+  | "entry", _, _ ->
+      failwith
+        (F.asprintf "@pp_syntax_entry: ill-formed entry:\n%a" pp_case_v value)
+  | _ ->
+      failwith
+        (Printf.sprintf "@pp_syntax_entry: expected entry, got %s"
+           (id_of_case_v value))
+
+and pp_syntax_table_prop ~level fmt (value : value) : unit =
+  match flatten_case_v value with
+  | "tableProperty", [ [ "KEY"; "="; "{" ]; [ "}" ] ], [ keys ] ->
+      F.fprintf fmt "key = {\n%a\n%s}"
+        (pp_list_v ~level:(level + 1) ~sep:Nl)
+        keys (indent level)
+  | "tableProperty", [ [ "ACTIONS"; "="; "{" ]; [ "}" ] ], [ actions ] ->
+      F.fprintf fmt "actions = {\n%a\n%s}"
+        (pp_list_v ~level:(level + 1) ~sep:Nl)
+        actions (indent level)
+  | ( "tableProperty",
+      [ []; []; [ "ENTRIES"; "="; "{" ]; [ "}" ] ],
+      [ opt_annos; opt_const; entries ] ) ->
+      F.fprintf fmt "%a%aentries = {\n%a\n%s}"
+        (pp_opt_annos ~level ~sep:Nl)
+        opt_annos
+        (pp_opt_v ~postfix:" " pp_case_v)
+        opt_const
+        (pp_list_v ~level:(level + 1) ~sep:Nl)
+        entries (indent level)
+  | ( "tableProperty",
+      [ []; []; []; []; [ ";" ] ],
+      [ opt_annos; opt_const; name; init ] ) ->
+      F.fprintf fmt "%a%a%a%a"
+        (pp_opt_annos ~level ~sep:Nl)
+        opt_annos
+        (pp_opt_v ~postfix:" " pp_case_v)
+        opt_const pp_case_v name pp_case_v init
+  | "tableProperty", _, _ ->
+      failwith
+        (F.asprintf "@pp_syntax_table_prop: ill-formed table property:\n%a"
+           pp_case_v value)
+  | _ ->
+      failwith
+        (Printf.sprintf "@pp_syntax_table_prop: expected table property, got %s"
+           (id_of_case_v value))
+
+and pp_syntax_ctrl_typ_decl ~level fmt (value : value) : unit =
+  match flatten_case_v value with
+  | ( "controlTypeDeclaration",
+      [ []; [ "CONTROL" ]; []; [ "(" ]; [ ")" ] ],
+      [ opt_annos; name; tparams; params ] ) ->
+      F.fprintf fmt "%acontrol %a%a(%a)"
+        (pp_opt_annos ~level ~sep:Nl)
+        opt_annos pp_case_v name
+        (pp_opt_v ~postfix:"" pp_case_v)
+        tparams
+        (pp_list_v ~level:0 ~sep:Comma)
+        params
+  | "controlTypeDeclaration", _, _ ->
+      failwith
+        (F.asprintf
+           "@pp_syntax_ctrl_typ_decl: ill-formed control type declaration:\n%a"
+           pp_case_v value)
+  | _ ->
+      failwith
+        (Printf.sprintf
+           "@pp_syntax_ctrl_typ_decl: expected control type declaration, got %s"
            (id_of_case_v value))
 
 and pp_syntax_decl ~level fmt (value : value) : unit =
@@ -703,24 +853,24 @@ and pp_syntax_decl ~level fmt (value : value) : unit =
       [ [ "MATCH_KIND"; "{" ]; []; [ "}" ] ],
       [ ids; comma ] ) ->
       F.fprintf fmt "match_kind {\n%a%a\n%s}"
-        (pp_list_v ~level:(level + 1) ~sep:Nl)
+        (pp_list_v ~level:(level + 1) ~sep:CommaNl)
         ids
         (pp_opt_v ~postfix:"" pp_case_v)
         comma (indent level)
-  | "errorDeclaration", [ [ "ERROR"; "{" ]; []; [ "}" ] ], [ ids; comma ] ->
-      F.fprintf fmt "error {\n%a%a\n%s}"
-        (pp_list_v ~level:(level + 1) ~sep:Nl)
-        ids
-        (pp_opt_v ~postfix:"" pp_case_v)
-        comma (indent level)
+  | "errorDeclaration", [ [ "ERROR"; "{" ]; [ "}" ] ], [ ids ] ->
+      F.fprintf fmt "error {\n%a\n%s}"
+        (pp_list_v ~level:(level + 1) ~sep:CommaNl)
+        ids (indent level)
   | ( "externDeclaration",
       [ []; [ "EXTERN" ]; []; [ "{" ]; [ "}" ] ],
       [ opt_annos; name; opt_tparams; mthds ] ) ->
-      F.fprintf fmt "%aextern %a%a {%a}"
+      F.fprintf fmt "%aextern %a%a {\n%a\n%s}"
         (pp_opt_annos ~level ~sep:Nl)
         opt_annos pp_case_v name
         (pp_opt_v ~postfix:"" pp_case_v)
-        opt_tparams (pp_list_v ~level ~sep:Nl) mthds
+        opt_tparams
+        (pp_list_v ~level:(level + 1) ~sep:Nl)
+        mthds (indent level)
   | "externDeclaration", [ []; [ "EXTERN" ]; [ ";" ] ], [ opt_annos; func ] ->
       F.fprintf fmt "%aextern %a;"
         (pp_opt_annos ~level ~sep:Nl)
@@ -755,19 +905,28 @@ and pp_syntax_decl ~level fmt (value : value) : unit =
         opt_annos pp_case_v name
         (pp_list_v ~level:0 ~sep:Comma)
         params (pp_syntax_stmt ~level) body
-  | "tableDeclaration", _, _ -> pp_default_case_v fmt value
-  | "parserDeclaration", _, _ -> pp_default_case_v fmt value
+  | ( "tableDeclaration",
+      [ []; [ "TABLE" ]; [ "{" ]; [ "}" ] ],
+      [ opt_annos; name; props ] ) ->
+      F.fprintf fmt "%atable %a {\n%a\n%s}"
+        (pp_opt_annos ~level ~sep:Nl)
+        opt_annos pp_case_v name
+        (pp_list_v ~level:(level + 1) ~sep:Nl)
+        props (indent level)
   | ( "controlDeclaration",
       [ []; []; [ "{" ]; [ "APPLY" ]; [ "}" ] ],
-      [ control_type_decl; opt_constructor_params; control_local_decls; body ] )
-    ->
-      F.fprintf fmt "%a%a {\n%a\n%sapply %a\n%s}" pp_default_case_v
-        control_type_decl pp_value opt_constructor_params
+      [ control_type_decl; opt_constructor_params; locals; apply_body ] ) ->
+      F.fprintf fmt "%a%a {\n%a\n%sapply %a\n%s}"
+        (pp_syntax_ctrl_typ_decl ~level)
+        control_type_decl
+        (pp_opt_v ~postfix:"" pp_case_v)
+        opt_constructor_params
         (pp_list_v ~level:(level + 1) ~sep:Nl)
-        control_local_decls
+        locals
         (indent (level + 1))
         (pp_syntax_stmt ~level:(level + 1))
-        body (indent level)
+        apply_body (indent level)
+  | "parserDeclaration", _, _ -> pp_default_case_v fmt value
   | ( "headerTypeDeclaration",
       [ []; [ "HEADER" ]; []; [ "{" ]; [ "}" ] ],
       [ _; _; _; _ ] )
@@ -781,7 +940,8 @@ and pp_syntax_decl ~level fmt (value : value) : unit =
   | "typeDeclaration", [ []; [ ";" ] ], [ _ ]
   | "typeDeclaration", [ []; [ ";"; "PHTM_13" ] ], [ _ ]
   | "typeDeclaration", [ []; [ ";"; "PHTM_14" ] ], [ _ ]
-  | "typeDeclaration", [ []; [ ";"; "PHTM_15" ] ], [ _ ]
+  | "typeDeclaration", [ []; [ ";"; "PHTM_15" ] ], [ _ ] ->
+      pp_default_case_v fmt value
   | _ ->
       failwith
         (Printf.sprintf "@pp_syntax_decl: expected declaration, got %s"
@@ -861,4 +1021,11 @@ and pp_case_v fmt (value : value) : unit =
       pp_syntax_stmt ~level:0 fmt value
   | "functionPrototype" -> pp_syntax_func fmt value
   | "methodPrototype" -> pp_syntax_mthd ~level:0 fmt value
+  | "keyElement" -> pp_syntax_key fmt value
+  | "actionRef" -> pp_syntax_action_ref fmt value
+  | "action" -> pp_syntax_action fmt value
+  | "entryPriority" -> pp_syntax_entry_prio fmt value
+  | "entry" -> pp_syntax_entry fmt value
+  | "tableProperty" -> pp_syntax_table_prop ~level:0 fmt value
+  | "controlTypeDeclaration" -> pp_syntax_ctrl_typ_decl ~level:0 fmt value
   | _ -> pp_case_v' fmt value

--- a/p4spec/lib/parsing/pp.ml
+++ b/p4spec/lib/parsing/pp.ml
@@ -94,10 +94,14 @@ and pp_list_v ?(level = 0) ~sep fmt (value : value) : unit =
   | "statementOrDeclaration" ->
       pp_list ~level (pp_syntax_stat_or_decl ~level) ~sep fmt values
   | "methodPrototype" -> pp_list ~level (pp_syntax_mthd ~level) ~sep fmt values
-  | "objDeclaration" | "controlLocalDeclaration" ->
+  | "objDeclaration" | "controlLocalDeclaration" | "parserLocalElement" ->
       pp_list ~level (pp_syntax_decl ~level) ~sep fmt values
   | "tableProperty" ->
       pp_list ~level (pp_syntax_table_prop ~level) ~sep fmt values
+  | "parserStatement" ->
+      pp_list ~level (pp_syntax_parser_stmt ~level) ~sep fmt values
+  | "parserState" ->
+      pp_list ~level (pp_syntax_parser_state ~level) ~sep fmt values
   | "declaration" when List.compare_length_with values 0 = 0 ->
       F.fprintf fmt ";"
   | "declaration" -> pp_list ~level (pp_syntax_decl ~level) ~sep fmt values
@@ -889,6 +893,102 @@ and pp_syntax_trans_stmt fmt (value : value) : unit =
            "@pp_syntax_trans_stmt: expected transition statement, got %s"
            (id_of_case_v value))
 
+and pp_syntax_parser_stmt ~level fmt (value : value) : unit =
+  match flatten_case_v value with
+  | "assignmentOrMethodCallStatement", _, _
+  | "directApplication", _, _
+  | "emptyStatement", _, _
+  | "conditionalStatement", _, _ ->
+      pp_syntax_stmt ~level fmt value
+  | "variableDeclaration", _, _ | "constantDeclaration", _, _ ->
+      pp_syntax_decl ~level fmt value
+  | "parserBlockStatement", [ []; [ "{" ]; [ "}" ] ], [ opt_annos; stmts ] ->
+      F.fprintf fmt "%a{\n%a\n%s}"
+        (pp_opt_annos ~level ~sep:SpaceSep)
+        opt_annos
+        (pp_list_v ~level:(level + 1) ~sep:Nl)
+        stmts (indent level)
+  | "parserBlockStatement", _, _ ->
+      failwith
+        (F.asprintf
+           "@pp_syntax_parser_stmt: ill-formed parser block statement:\n%a"
+           pp_case_v value)
+  | _ ->
+      failwith
+        (Printf.sprintf
+           "@pp_syntax_parser_stmt: expected parser statement, got %s"
+           (id_of_case_v value))
+
+and pp_syntax_parser_state ~level fmt (value : value) : unit =
+  match flatten_case_v value with
+  | ( "parserState",
+      [ []; [ "STATE" ]; [ "{" ]; []; [ "}" ] ],
+      [ opt_annos; name; stmts; trans ] ) ->
+      F.fprintf fmt "%astate %a {\n%a\n%s%a\n%s}"
+        (pp_opt_annos ~level ~sep:Nl)
+        opt_annos pp_case_v name
+        (pp_list_v ~level:(level + 1) ~sep:Nl)
+        stmts
+        (indent (level + 1))
+        pp_case_v trans (indent level)
+  | "parserState", _, _ ->
+      failwith
+        (F.asprintf "@pp_syntax_parser_state: ill-formed parser state:\n%a"
+           pp_case_v value)
+  | _ ->
+      failwith
+        (Printf.sprintf "@pp_syntax_parser_state: expected parser state, got %s"
+           (id_of_case_v value))
+
+and pp_syntax_parser_type_decl ~level fmt (value : value) : unit =
+  match flatten_case_v value with
+  | ( "parserTypeDeclaration",
+      [ []; [ "PARSER" ]; []; [ "(" ]; [ ")" ] ],
+      [ opt_annos; name; opt_tparams; params ] ) ->
+      F.fprintf fmt "%aparser %a%a(%a)"
+        (pp_opt_annos ~level ~sep:Nl)
+        opt_annos pp_case_v name
+        (pp_opt_v ~postfix:"" pp_case_v)
+        opt_tparams
+        (pp_list_v ~level:0 ~sep:Comma)
+        params
+  | "parserTypeDeclaration", _, _ ->
+      failwith
+        (F.asprintf
+           "@pp_syntax_parser_type_decl: ill-formed parser type declaration:\n\
+            %a"
+           pp_case_v value)
+  | _ ->
+      failwith
+        (Printf.sprintf
+           "@pp_syntax_parser_type_decl: expected parser type declaration, got \
+            %s"
+           (id_of_case_v value))
+
+and pp_syntax_pckg_type_decl ~level fmt (value : value) : unit =
+  match flatten_case_v value with
+  | ( "packageTypeDeclaration",
+      [ []; [ "PACKAGE" ]; []; [ "(" ]; [ ")" ] ],
+      [ opt_annos; name; opt_tparams; params ] ) ->
+      F.fprintf fmt "%apackage %a%a(%a)"
+        (pp_opt_annos ~level ~sep:Nl)
+        opt_annos pp_case_v name
+        (pp_opt_v ~postfix:"" pp_case_v)
+        opt_tparams
+        (pp_list_v ~level:0 ~sep:Comma)
+        params
+  | "packageTypeDeclaration", _, _ ->
+      failwith
+        (F.asprintf
+           "@pp_syntax_pckg_type_decl: ill-formed package type declaration:\n%a"
+           pp_case_v value)
+  | _ ->
+      failwith
+        (Printf.sprintf
+           "@pp_syntax_pckg_type_decl: expected package type declaration, got \
+            %s"
+           (id_of_case_v value))
+
 and pp_syntax_decl ~level fmt (value : value) : unit =
   match flatten_case_v value with
   | ( "constantDeclaration",
@@ -994,7 +1094,20 @@ and pp_syntax_decl ~level fmt (value : value) : unit =
       F.fprintf fmt "%avalueset<%a>(%a) %a"
         (pp_opt_annos ~level ~sep:Nl)
         opt_annos pp_case_v type_name pp_case_v size pp_case_v name
-  | "parserDeclaration", _, _ -> pp_default_case_v fmt value
+  | ( "parserDeclaration",
+      [ []; []; [ "{" ]; []; [ "}" ] ],
+      [ decl; params; locals; states ] ) ->
+      F.fprintf fmt "%a%a {\n%s%a\n%s%a\n%s}"
+        (pp_syntax_parser_type_decl ~level)
+        decl
+        (pp_opt_v ~postfix:"" pp_case_v)
+        params
+        (indent (level + 1))
+        (pp_list_v ~level:(level + 1) ~sep:Nl)
+        locals
+        (indent (level + 1))
+        (pp_list_v ~level:(level + 1) ~sep:Nl)
+        states (indent level)
   | ( "headerTypeDeclaration",
       [ []; [ "HEADER" ]; []; [ "{" ]; [ "}" ] ],
       [ _; _; _; _ ] )
@@ -1102,4 +1215,9 @@ and pp_case_v fmt (value : value) : unit =
   | "controlTypeDeclaration" -> pp_syntax_ctrl_typ_decl ~level:0 fmt value
   | "selectCase" -> pp_syntax_select_case fmt value
   | "selectExpression" -> pp_syntax_select_expr ~level:0 fmt value
+  | "transitionStatement" -> pp_syntax_trans_stmt fmt value
+  | "parserBlockStatement" -> pp_syntax_parser_stmt ~level:0 fmt value
+  | "parserState" -> pp_syntax_parser_state ~level:0 fmt value
+  | "parserTypeDeclaration" -> pp_syntax_parser_type_decl ~level:0 fmt value
+  | "packageTypeDeclaration" -> pp_syntax_pckg_type_decl ~level:0 fmt value
   | _ -> pp_case_v' fmt value

--- a/p4spec/lib/parsing/pp.ml
+++ b/p4spec/lib/parsing/pp.ml
@@ -57,8 +57,8 @@ and pp_value fmt (value : value) : unit =
       F.fprintf fmt "(%s)"
         (String.concat ", "
            (List.map (fun v -> F.asprintf "%a" pp_value v) values))
-  | OptV _ -> pp_opt_v fmt value
-  | ListV _ -> pp_list_v fmt value
+  | OptV _ -> pp_opt_v pp_value fmt value
+  | ListV _ -> pp_list_v ~sep:Nl fmt value
   | _ -> failwith "@pp_value: TODO"
 
 and pp_text_v fmt (value : value) : unit =
@@ -66,13 +66,13 @@ and pp_text_v fmt (value : value) : unit =
   | TextV text -> F.fprintf fmt "%s" text
   | _ -> failwith "@pp_text_v: expected TextV value"
 
-and pp_opt_v ?(postfix = "") fmt (value : value) : unit =
+and pp_opt_v ?(postfix = "") pp_v fmt (value : value) : unit =
   match value.it with
-  | OptV (Some v) -> F.fprintf fmt "%a%s" pp_value v postfix
+  | OptV (Some v) -> F.fprintf fmt "%a%s" pp_v v postfix
   | OptV None -> F.fprintf fmt ""
   | _ -> failwith "@pp_opt_v: expected OptV value"
 
-and pp_list_v ?(level = 0) fmt (value : value) : unit =
+and pp_list_v ?(level = 0) ~sep fmt (value : value) : unit =
   let values =
     match value.it with
     | ListV values -> values
@@ -83,17 +83,17 @@ and pp_list_v ?(level = 0) fmt (value : value) : unit =
   match id_of_list_v value with
   | "identifier" | "typeParameterList" | "parameter" | "expression" | "kvPair"
   | "simpleKeysetExpression" | "realTypeArg" | "typeArg" | "argument" ->
-      pp_list pp_case_v ~sep:Comma fmt values
-  | "switchCase" -> pp_list ~level (pp_syntax_stmt' ~level) ~sep:Nl fmt values
+      pp_list pp_case_v ~sep fmt values
+  | "switchCase" -> pp_list ~level (pp_syntax_stmt' ~level) ~sep fmt values
   | "declOrAssignmentOrMethodCallStatement" ->
-      pp_list pp_syntax_decl_or_assign_or_call_stmt ~sep:Comma fmt values
+      pp_list pp_syntax_decl_or_assign_or_call_stmt ~sep fmt values
   | "assignmentOrMethodCallStatement" ->
-      pp_list (pp_syntax_stmt' ~level:0) ~sep:Comma fmt values
+      pp_list (pp_syntax_stmt' ~level:0) ~sep fmt values
   | "statementOrDeclaration" ->
-      pp_list ~level (pp_syntax_stat_or_decl ~level) ~sep:Nl fmt values
+      pp_list ~level (pp_syntax_stat_or_decl ~level) ~sep fmt values
   | "declaration" when List.compare_length_with values 0 = 0 ->
       F.fprintf fmt ";"
-  | "declaration" -> pp_list ~level (pp_syntax_decl ~level) ~sep:Nl fmt values
+  | "declaration" -> pp_list ~level (pp_syntax_decl ~level) ~sep fmt values
   | _ ->
       failwith
         (Printf.sprintf "@pp_list_v: unknown ListV: %s" (id_of_list_v value))
@@ -180,7 +180,8 @@ and pp_syntax_type fmt (value : value) : unit =
       failwith
         (F.asprintf "@pp_syntax_type: ill-formed base type:\n%a" pp_case_v value)
   | "specializedType", [ []; [ "<" ]; [ ">" ] ], [ type_name; type_arg_list ] ->
-      F.fprintf fmt "%a<%a>" pp_case_v type_name (pp_list_v ~level:0)
+      F.fprintf fmt "%a<%a>" pp_case_v type_name
+        (pp_list_v ~level:0 ~sep:Comma)
         type_arg_list
   | "specializedType", _, _ ->
       failwith
@@ -201,7 +202,7 @@ and pp_syntax_type fmt (value : value) : unit =
       failwith
         (F.asprintf "@pp_syntax_type: ill-formed list type:\n%a" pp_case_v value)
   | "tupleType", [ [ "TUPLE"; "<" ]; [ ">" ] ], [ type_arg_list ] ->
-      F.fprintf fmt "tuple<%a>" (pp_list_v ~level:0) type_arg_list
+      F.fprintf fmt "tuple<%a>" (pp_list_v ~level:0 ~sep:Comma) type_arg_list
   | "tupleType", _, _ ->
       failwith
         (F.asprintf "@pp_syntax_type: ill-formed tuple type:\n%a" pp_case_v
@@ -214,7 +215,7 @@ and pp_syntax_type fmt (value : value) : unit =
 and pp_syntax_tparams fmt (value : value) : unit =
   match flatten_case_v value with
   | "typeParameters", [ [ "<" ]; [ ">" ] ], [ tparams ] ->
-      F.fprintf fmt "<%a>" (pp_list_v ~level:0) tparams
+      F.fprintf fmt "<%a>" (pp_list_v ~level:0 ~sep:Comma) tparams
   | "typeParameters", _, _ ->
       failwith
         (F.asprintf "@pp_syntax_tparams: ill-formed type parameters:\n%a"
@@ -227,19 +228,21 @@ and pp_syntax_tparams fmt (value : value) : unit =
 and pp_syntax_params fmt (value : value) : unit =
   match flatten_case_v value with
   | "parameter", [ []; []; []; []; [] ], [ opt_annos; dir; type_ref; name ] ->
-      F.fprintf fmt "%a%a %a %a" (pp_opt_v ~postfix:" ") opt_annos pp_case_v dir
-        pp_case_v type_ref pp_case_v name
+      F.fprintf fmt "%a%a %a %a"
+        (pp_opt_annos ~level:0 ~sep:SpaceSep)
+        opt_annos pp_case_v dir pp_case_v type_ref pp_case_v name
   | ( "parameter",
       [ []; []; []; []; []; [] ],
       [ opt_annos; dir; type_ref; name; init ] ) ->
-      F.fprintf fmt "%a%a %a %a%a" (pp_opt_v ~postfix:" ") opt_annos pp_case_v
-        dir pp_case_v type_ref pp_case_v name pp_case_v init
+      F.fprintf fmt "%a%a %a %a%a"
+        (pp_opt_annos ~level:0 ~sep:SpaceSep)
+        opt_annos pp_case_v dir pp_case_v type_ref pp_case_v name pp_case_v init
   | "parameter", _, _ ->
       failwith
         (F.asprintf "@pp_syntax_params: ill-formed parameter:\n%a" pp_case_v
            value)
   | "constructorParameters", [ [ "(" ]; [ ")" ] ], [ params ] ->
-      F.fprintf fmt "(%a)" (pp_list_v ~level:0) params
+      F.fprintf fmt "(%a)" (pp_list_v ~level:0 ~sep:Comma) params
   | _ ->
       failwith
         (Printf.sprintf "@pp_syntax_params: expected parameter, got %s"
@@ -285,12 +288,19 @@ and pp_syntax_nb_expr fmt (value : value) : unit =
   | ( "nonBraceExpression",
       [ []; [ "<" ]; [ ">"; "(" ]; [ ")" ] ],
       [ func; type_args; args ] ) ->
-      F.fprintf fmt "(%a)<%a>(%a)" pp_case_v func (pp_list_v ~level:0) type_args
-        (pp_list_v ~level:0) args
+      F.fprintf fmt "(%a)<%a>(%a)" pp_case_v func
+        (pp_list_v ~level:0 ~sep:Comma)
+        type_args
+        (pp_list_v ~level:0 ~sep:Comma)
+        args
   | "nonBraceExpression", [ []; [ "(" ]; [ ")" ] ], [ func; args ] ->
-      F.fprintf fmt "(%a)(%a)" pp_case_v func (pp_list_v ~level:0) args
+      F.fprintf fmt "(%a)(%a)" pp_case_v func
+        (pp_list_v ~level:0 ~sep:Comma)
+        args
   | "nonBraceExpression", [ []; [ "(" ]; [ ")"; "PHTM_6" ] ], [ typ; args ] ->
-      F.fprintf fmt "(%a)(%a)" pp_case_v typ (pp_list_v ~level:0) args
+      F.fprintf fmt "(%a)(%a)" pp_case_v typ
+        (pp_list_v ~level:0 ~sep:Comma)
+        args
   | "nonBraceExpression", [ [ "(" ]; [ ")" ]; [] ], [ typ; expr ] ->
       F.fprintf fmt "(%a)(%a)" pp_case_v typ pp_case_v expr
   | "nonBraceExpression", _, _ ->
@@ -322,15 +332,24 @@ and pp_syntax_expr fmt (value : value) : unit =
   | "expression", [ []; [ "[" ]; [ ":" ]; [ "]" ] ], [ bits; hi; lo ] ->
       F.fprintf fmt "(%a)[%a:%a]" pp_case_v bits pp_case_v hi pp_case_v lo
   | "expression", [ [ "{" ]; []; [ "}" ] ], [ exprs; comma ] ->
-      F.fprintf fmt "{ %a%a }" (pp_list_v ~level:0) exprs (pp_opt_v ~postfix:"")
+      F.fprintf fmt "{ %a%a }"
+        (pp_list_v ~level:0 ~sep:Comma)
+        exprs
+        (pp_opt_v ~postfix:"" pp_case_v)
         comma
   | "expression", [ [ "INVALID" ] ], [] -> F.fprintf fmt "{#}"
   | "expression", [ [ "{" ]; []; [ "}"; "PHTM_7" ] ], [ kvs; comma ] ->
-      F.fprintf fmt "{ %a%a }" (pp_list_v ~level:0) kvs (pp_opt_v ~postfix:"")
+      F.fprintf fmt "{ %a%a }"
+        (pp_list_v ~level:0 ~sep:Comma)
+        kvs
+        (pp_opt_v ~postfix:"" pp_case_v)
         comma
   | "expression", [ [ "{" ]; [ ","; "..." ]; [ "}" ] ], [ kvs; comma ] ->
-      F.fprintf fmt "{ %a, ...%a }" (pp_list_v ~level:0) kvs
-        (pp_opt_v ~postfix:"") comma
+      F.fprintf fmt "{ %a, ...%a }"
+        (pp_list_v ~level:0 ~sep:Comma)
+        kvs
+        (pp_opt_v ~postfix:"" pp_case_v)
+        comma
   | "expression", [ [ "!" ]; [] ], [ arg ] ->
       F.fprintf fmt "!(%a)" pp_case_v arg
   | "expression", [ [ "~" ]; [] ], [ arg ] ->
@@ -357,12 +376,19 @@ and pp_syntax_expr fmt (value : value) : unit =
   | ( "expression",
       [ []; [ "<" ]; [ ">"; "(" ]; [ ")" ] ],
       [ func; type_args; args ] ) ->
-      F.fprintf fmt "(%a)<%a>(%a)" pp_case_v func (pp_list_v ~level:0) type_args
-        (pp_list_v ~level:0) args
+      F.fprintf fmt "(%a)<%a>(%a)" pp_case_v func
+        (pp_list_v ~level:0 ~sep:Comma)
+        type_args
+        (pp_list_v ~level:0 ~sep:Comma)
+        args
   | "expression", [ []; [ "(" ]; [ ")" ] ], [ func; args ] ->
-      F.fprintf fmt "(%a)(%a)" pp_case_v func (pp_list_v ~level:0) args
+      F.fprintf fmt "(%a)(%a)" pp_case_v func
+        (pp_list_v ~level:0 ~sep:Comma)
+        args
   | "expression", [ []; [ "(" ]; [ ")"; "PHTM_6" ] ], [ typ; args ] ->
-      F.fprintf fmt "(%a)(%a)" pp_case_v typ (pp_list_v ~level:0) args
+      F.fprintf fmt "(%a)(%a)" pp_case_v typ
+        (pp_list_v ~level:0 ~sep:Comma)
+        args
   | "expression", _, _ ->
       failwith
         (F.asprintf "@pp_syntax_expr: ill-formed expression:\n%a" pp_case_v
@@ -399,7 +425,9 @@ and pp_syntax_keyset_expr fmt (value : value) : unit =
             %a"
            pp_case_v value)
   | "tupleKeysetExpression", [ [ "(" ]; [ "," ]; [ ")" ] ], [ expr; exprs ] ->
-      F.fprintf fmt "(%a, %a)" pp_case_v expr (pp_list_v ~level:0) exprs
+      F.fprintf fmt "(%a, %a)" pp_case_v expr
+        (pp_list_v ~level:0 ~sep:Comma)
+        exprs
   | "tupleKeysetExpression", [ [ "(" ]; [ ")"; "PHTM_19" ] ], [ expr ] ->
       F.fprintf fmt "(%a)" pp_case_v expr
   | "tupleKeysetExpression", _, _ ->
@@ -490,12 +518,15 @@ and pp_syntax_stmt' ~level fmt (value : value) : unit =
   | ( "assignmentOrMethodCallStatementWithoutSemicolon",
       [ []; [ "(" ]; [ ")" ] ],
       [ func; args ] ) ->
-      F.fprintf fmt "%a(%a)" pp_case_v func (pp_list_v ~level) args
+      F.fprintf fmt "%a(%a)" pp_case_v func (pp_list_v ~level ~sep:Comma) args
   | ( "assignmentOrMethodCallStatementWithoutSemicolon",
       [ []; [ "<" ]; [ ">"; "(" ]; [ ")" ] ],
       [ func; targs; args ] ) ->
-      F.fprintf fmt "%a<%a>(%a)" pp_case_v func (pp_list_v ~level) targs
-        (pp_list_v ~level) args
+      F.fprintf fmt "%a<%a>(%a)" pp_case_v func
+        (pp_list_v ~level ~sep:Comma)
+        targs
+        (pp_list_v ~level ~sep:Comma)
+        args
   | ( "assignmentOrMethodCallStatementWithoutSemicolon",
       [ []; [ assign_op ]; [] ],
       [ lhs; rhs ] )
@@ -524,13 +555,17 @@ and pp_syntax_stmt ~level fmt (value : value) : unit =
   | ( "directApplication",
       [ []; [ "."; "APPLY"; "(" ]; [ ")"; ";" ] ],
       [ named_type; args ] ) ->
-      F.fprintf fmt "%a.apply(%a);" pp_case_v named_type (pp_list_v ~level) args
+      F.fprintf fmt "%a.apply(%a);" pp_case_v named_type
+        (pp_list_v ~level ~sep:Comma)
+        args
   | "conditionalStatement", [ [ "IF"; "(" ]; [ ")" ]; [] ], [ cond; tru ] ->
       F.fprintf fmt "if (%a) %a" pp_case_v cond (pp_syntax_stmt ~level) tru
   | "emptyStatement", [ [ ";" ] ], [] -> F.fprintf fmt ";"
-  | "blockStatement", [ []; [ "{" ]; [ "}" ] ], [ annos; stmts ] ->
-      F.fprintf fmt "%a{\n%a\n%s}" (pp_opt_v ~postfix:" ") annos
-        (pp_list_v ~level:(level + 1))
+  | "blockStatement", [ []; [ "{" ]; [ "}" ] ], [ opt_annos; stmts ] ->
+      F.fprintf fmt "%a{\n%a\n%s}"
+        (pp_opt_annos ~level ~sep:SpaceSep)
+        opt_annos
+        (pp_list_v ~level:(level + 1) ~sep:Nl)
         stmts (indent level)
   | "returnStatement", [ [ "RETURN"; ";" ] ], [] -> F.fprintf fmt "return;"
   | "returnStatement", [ [ "RETURN" ]; [ ";" ] ], [ expr ] ->
@@ -542,18 +577,43 @@ and pp_syntax_stmt ~level fmt (value : value) : unit =
   | ( "switchStatement",
       [ [ "SWITCH"; "(" ]; [ ")"; "{" ]; [ "}" ] ],
       [ expr; cases ] ) ->
-      F.fprintf fmt "switch (%a) {\n%a\n%s}" pp_case_v expr (pp_list_v ~level)
-        cases (indent level)
+      F.fprintf fmt "switch (%a) {\n%a\n%s}" pp_case_v expr
+        (pp_list_v ~level ~sep:Nl) cases (indent level)
   | ( "forStatement",
       [ []; [ "FOR"; "(" ]; [ ";" ]; [ ";" ]; [ ")" ]; [] ],
-      [ anno; init; cond; update; body ] ) ->
-      F.fprintf fmt "%afor (%a; %a; %a) %a"
-        (pp_opt_v ~postfix:(F.sprintf "\n%s" (indent level)))
-        anno (pp_list_v ~level:0) init pp_case_v cond (pp_list_v ~level:0)
+      [ opt_annos; init; cond; update; body ] ) ->
+      let pp_opt_annos =
+        pp_opt_v
+          ~postfix:(F.sprintf "\n%s" (indent level))
+          (pp_list_v ~level ~sep:Nl)
+      in
+      F.fprintf fmt "%afor (%a; %a; %a) %a" pp_opt_annos opt_annos
+        (pp_list_v ~level:0 ~sep:Comma)
+        init pp_case_v cond
+        (pp_list_v ~level:0 ~sep:Comma)
         update (pp_syntax_stmt ~level) body
   | _ ->
       failwith
         (Printf.sprintf "@pp_syntax_stmt: expected statement, got %s"
+           (id_of_case_v value))
+
+and pp_syntax_func fmt (value : value) : unit =
+  match flatten_case_v value with
+  | ( "functionPrototype",
+      [ []; []; []; [ "(" ]; [ ")" ] ],
+      [ typ_or_void; name; opt_tparams; params ] ) ->
+      let pp_opt_tparams = pp_opt_v ~postfix:"" pp_case_v in
+      F.fprintf fmt "%a %a%a(%a)" pp_case_v typ_or_void pp_case_v name
+        pp_opt_tparams opt_tparams
+        (pp_list_v ~level:0 ~sep:Comma)
+        params
+  | "functionPrototype", _, _ ->
+      failwith
+        (F.asprintf "@pp_syntax_func: ill-formed function prototype:\n%a"
+           pp_default_case_v value)
+  | _ ->
+      failwith
+        (Printf.sprintf "@pp_syntax_func: expected function prototype, got %s"
            (id_of_case_v value))
 
 and pp_syntax_mthd fmt (value : value) : unit =
@@ -569,19 +629,6 @@ and pp_syntax_mthd fmt (value : value) : unit =
   | _ ->
       failwith
         (Printf.sprintf "@pp_syntax_method: expected methodPrototype, got %s"
-           (id_of_case_v value))
-
-and pp_syntax_block fmt (value : value) : unit =
-  match flatten_case_v value with
-  | "blockStatement", [ []; [ "{" ]; [ "}" ] ], [ _; _ ] ->
-      F.fprintf fmt "%a" pp_default_case_v value
-  | "blockStatement", _, _ ->
-      failwith
-        (F.asprintf "@pp_syntax_block: ill-formed blockStatement:\n%a"
-           pp_default_case_v value)
-  | _ ->
-      failwith
-        (Printf.sprintf "@pp_syntax_block: expected block, got %s"
            (id_of_case_v value))
 
 and pp_syntax_stat_or_decl ~level fmt (value : value) : unit =
@@ -617,13 +664,26 @@ and pp_syntax_decl ~level fmt (value : value) : unit =
   match flatten_case_v value with
   | ( "constantDeclaration",
       [ []; [ "CONST" ]; []; []; [ ";" ] ],
-      [ opt_annos; type_ref; name; opt_init ] ) ->
-      F.fprintf fmt "%aconst %a %a%a;" (pp_opt_v ~postfix:" ") opt_annos
-        pp_case_v type_ref pp_case_v name (pp_opt_v ~postfix:"") opt_init
+      [ opt_annos; type_ref; name; init ] ) ->
+      F.fprintf fmt "%aconst %a %a%a;"
+        (pp_opt_annos ~level ~sep:Nl)
+        opt_annos pp_case_v type_ref pp_case_v name pp_case_v init
   | "variableDeclaration", [ []; [ ";" ] ], [ decl ] ->
       F.fprintf fmt "%a;" pp_case_v decl
-  | "errorDeclaration", _, _
-  | "matchKindDeclaration", _, _
+  | ( "matchKindDeclaration",
+      [ [ "MATCH_KIND"; "{" ]; []; [ "}" ] ],
+      [ ids; comma ] ) ->
+      F.fprintf fmt "match_kind {\n%a%a\n%s}"
+        (pp_list_v ~level:(level + 1) ~sep:Nl)
+        ids
+        (pp_opt_v ~postfix:"" pp_case_v)
+        comma (indent level)
+  | "errorDeclaration", [ [ "ERROR"; "{" ]; []; [ "}" ] ], [ ids; comma ] ->
+      F.fprintf fmt "error {\n%a%a\n%s}"
+        (pp_list_v ~level:(level + 1) ~sep:Nl)
+        ids
+        (pp_opt_v ~postfix:"" pp_case_v)
+        comma (indent level)
   | ( "externDeclaration",
       [ []; [ "EXTERN" ]; []; [ "{" ]; [ "}" ] ],
       [ _; _; _; _ ] )
@@ -639,10 +699,11 @@ and pp_syntax_decl ~level fmt (value : value) : unit =
     ->
       F.fprintf fmt "%a%a {\n%a\n%sapply %a\n%s}" pp_default_case_v
         control_type_decl pp_value opt_constructor_params
-        (pp_list_v ~level:(level + 1))
+        (pp_list_v ~level:(level + 1) ~sep:Nl)
         control_local_decls
         (indent (level + 1))
-        pp_syntax_block body (indent level)
+        (pp_syntax_stmt ~level:(level + 1))
+        body (indent level)
   | ( "headerTypeDeclaration",
       [ []; [ "HEADER" ]; []; [ "{" ]; [ "}" ] ],
       [ _; _; _; _ ] )
@@ -663,6 +724,10 @@ and pp_syntax_decl ~level fmt (value : value) : unit =
       failwith
         (Printf.sprintf "@pp_syntax_decl: expected declaration, got %s"
            (id_of_case_v value))
+
+and pp_opt_annos ?(level = 0) ~sep fmt (value : value) : unit =
+  let postfix = if is_nl sep then F.sprintf "\n%s" (indent level) else " " in
+  pp_opt_v ~postfix (pp_list_v ~level ~sep) fmt value
 
 and pp_case_v' fmt (value : value) : unit =
   match flatten_case_v value with
@@ -690,8 +755,11 @@ and pp_case_v' fmt (value : value) : unit =
   | ( "variableDeclarationWithoutSemicolon",
       [ []; []; []; []; [] ],
       [ opt_anno; type_ref; name; opt_init ] ) ->
-      F.fprintf fmt "%a%a %a%a" (pp_opt_v ~postfix:" ") opt_anno pp_case_v
-        type_ref pp_case_v name (pp_opt_v ~postfix:"") opt_init
+      F.fprintf fmt "%a%a %a%a"
+        (pp_opt_annos ~level:0 ~sep:SpaceSep)
+        opt_anno pp_case_v type_ref pp_case_v name
+        (pp_opt_v ~postfix:"" pp_case_v)
+        opt_init
   | _ -> pp_default_case_v fmt value
 
 and pp_case_v fmt (value : value) : unit =
@@ -728,4 +796,5 @@ and pp_case_v fmt (value : value) : unit =
   | "returnStatement" | "breakStatement" | "continueStatement" | "exitStatement"
   | "switchStatement" | "forStatement" ->
       pp_syntax_stmt ~level:0 fmt value
+  | "functionPrototype" -> pp_syntax_func fmt value
   | _ -> pp_case_v' fmt value

--- a/p4spec/lib/parsing/pp.ml
+++ b/p4spec/lib/parsing/pp.ml
@@ -83,8 +83,8 @@ and pp_list_v ?(level = 0) ~sep fmt (value : value) : unit =
   match id_of_list_v value with
   | "identifier" | "typeParameterList" | "parameter" | "expression" | "kvPair"
   | "simpleKeysetExpression" | "realTypeArg" | "typeArg" | "argument"
-  | "keyElement" | "action" | "entry" | "selectCase" | "annotation"
-  | "simpleAnnotation" ->
+  | "keyElement" | "action" | "entry" | "selectCase" | "specifiedIdentifier"
+  | "structField" | "annotation" | "simpleAnnotation" ->
       pp_list ~level pp_case_v ~sep fmt values
   | "switchCase" -> pp_list ~level (pp_syntax_stmt' ~level) ~sep fmt values
   | "declOrAssignmentOrMethodCallStatement" ->
@@ -508,7 +508,7 @@ and pp_syntax_lvalue fmt (value : value) : unit =
 and pp_syntax_init fmt (value : value) : unit =
   match flatten_case_v value with
   | "initializer", [ [ "=" ]; [] ], [ expr ] ->
-      F.fprintf fmt " = (%a)" pp_syntax_expr expr
+      F.fprintf fmt " = (%a)" pp_case_v expr
   | "initializer", _, _ ->
       failwith
         (F.asprintf "@pp_syntax_init: ill-formed initializer:\n%a" pp_case_v
@@ -571,6 +571,11 @@ and pp_syntax_stmt ~level fmt (value : value) : unit =
         args
   | "conditionalStatement", [ [ "IF"; "(" ]; [ ")" ]; [] ], [ cond; tru ] ->
       F.fprintf fmt "if (%a) %a" pp_case_v cond (pp_syntax_stmt ~level) tru
+  | ( "conditionalStatement",
+      [ [ "IF"; "(" ]; [ ")" ]; [ "ELSE" ]; [] ],
+      [ cond; tru; fls ] ) ->
+      F.fprintf fmt "if (%a) %a else %a" pp_case_v cond (pp_syntax_stmt ~level)
+        tru (pp_syntax_stmt ~level) fls
   | "emptyStatement", [ [ ";" ] ], [] -> F.fprintf fmt ";"
   | "blockStatement", [ []; [ "{" ]; [ "}" ] ], [ opt_annos; stmts ] ->
       F.fprintf fmt "%a{\n%a\n%s}"
@@ -877,11 +882,26 @@ and pp_syntax_select_expr ~level fmt (value : value) : unit =
            "@pp_syntax_select_expr: expected select expression, got %s"
            (id_of_case_v value))
 
-and pp_syntax_trans_stmt fmt (value : value) : unit =
+and pp_syntax_state_expr ~level fmt (value : value) : unit =
+  match flatten_case_v value with
+  | "stateExpression", [ []; [ ";" ] ], [ name ] ->
+      F.fprintf fmt "%a;" pp_case_v name
+  | "stateExpression", _, _ ->
+      failwith
+        (F.asprintf "@pp_syntax_state_expr: ill-formed state expression:\n%a"
+           pp_case_v value)
+  | "selectExpression", _, _ -> pp_syntax_select_expr ~level fmt value
+  | _ ->
+      failwith
+        (Printf.sprintf
+           "@pp_syntax_state_expr: expected state expression, got %s"
+           (id_of_case_v value))
+
+and pp_syntax_trans_stmt ~level fmt (value : value) : unit =
   match flatten_case_v value with
   | "transitionStatement", [ [ "SPEC_BUG" ] ], [] -> ()
   | "transitionStatement", [ [ "TRANSITION" ]; [] ], [ state_expr ] ->
-      F.fprintf fmt "transition %a" pp_case_v state_expr
+      F.fprintf fmt "transition %a" (pp_syntax_state_expr ~level) state_expr
   | "transitionStatement", _, _ ->
       failwith
         (F.asprintf
@@ -930,7 +950,8 @@ and pp_syntax_parser_state ~level fmt (value : value) : unit =
         (pp_list_v ~level:(level + 1) ~sep:Nl)
         stmts
         (indent (level + 1))
-        pp_case_v trans (indent level)
+        (pp_syntax_trans_stmt ~level:(level + 1))
+        trans (indent level)
   | "parserState", _, _ ->
       failwith
         (F.asprintf "@pp_syntax_parser_state: ill-formed parser state:\n%a"
@@ -1097,32 +1118,91 @@ and pp_syntax_decl ~level fmt (value : value) : unit =
   | ( "parserDeclaration",
       [ []; []; [ "{" ]; []; [ "}" ] ],
       [ decl; params; locals; states ] ) ->
-      F.fprintf fmt "%a%a {\n%s%a\n%s%a\n%s}"
+      F.fprintf fmt "%a%a {\n%a\n%a\n%s}"
         (pp_syntax_parser_type_decl ~level)
         decl
         (pp_opt_v ~postfix:"" pp_case_v)
         params
-        (indent (level + 1))
         (pp_list_v ~level:(level + 1) ~sep:Nl)
         locals
-        (indent (level + 1))
         (pp_list_v ~level:(level + 1) ~sep:Nl)
         states (indent level)
-  | ( "headerTypeDeclaration",
-      [ []; [ "HEADER" ]; []; [ "{" ]; [ "}" ] ],
-      [ _; _; _; _ ] )
+  | ( "enumDeclaration",
+      [ []; [ "ENUM" ]; [ "{" ]; []; [ "}" ] ],
+      [ opt_annos; name; ids; opt_comma ] ) ->
+      F.fprintf fmt "%aenum %a {\n%a%a\n%s}"
+        (pp_opt_annos ~level ~sep:Nl)
+        opt_annos pp_case_v name
+        (pp_list_v ~level:(level + 1) ~sep:CommaNl)
+        ids
+        (pp_opt_v ~postfix:"" pp_case_v)
+        opt_comma (indent level)
+  | ( "enumDeclaration",
+      [ []; [ "ENUM" ]; []; [ "{" ]; []; [ "}" ] ],
+      [ opt_annos; type_ref; name; ids; opt_comma ] ) ->
+      F.fprintf fmt "%aenum %a %a {\n%a%a\n%s}"
+        (pp_opt_annos ~level ~sep:Nl)
+        opt_annos pp_case_v type_ref pp_case_v name
+        (pp_list_v ~level:(level + 1) ~sep:CommaNl)
+        ids
+        (pp_opt_v ~postfix:"" pp_case_v)
+        opt_comma (indent level)
   | ( "headerUnionDeclaration",
       [ []; [ "HEADER_UNION" ]; []; [ "{" ]; [ "}" ] ],
-      [ _; _; _; _ ] )
+      [ opt_annos; name; tparams; fields ] ) ->
+      F.fprintf fmt "%aheader_union %a%a {\n%a\n%s}"
+        (pp_opt_annos ~level ~sep:Nl)
+        opt_annos pp_case_v name
+        (pp_opt_v ~postfix:"" pp_case_v)
+        tparams
+        (pp_list_v ~level:(level + 1) ~sep:Nl)
+        fields (indent level)
   | ( "structTypeDeclaration",
       [ []; [ "STRUCT" ]; []; [ "{" ]; [ "}" ] ],
-      [ _; _; _; _ ] )
-  | "enumDeclaration", _, _
-  | "typeDeclaration", [ []; [ ";" ] ], [ _ ]
-  | "typeDeclaration", [ []; [ ";"; "PHTM_13" ] ], [ _ ]
-  | "typeDeclaration", [ []; [ ";"; "PHTM_14" ] ], [ _ ]
-  | "typeDeclaration", [ []; [ ";"; "PHTM_15" ] ], [ _ ] ->
-      pp_default_case_v fmt value
+      [ opt_annos; name; tparams; fields ] ) ->
+      F.fprintf fmt "%astruct %a%a {\n%a\n%s}"
+        (pp_opt_annos ~level ~sep:Nl)
+        opt_annos pp_case_v name
+        (pp_opt_v ~postfix:"" pp_case_v)
+        tparams
+        (pp_list_v ~level:(level + 1) ~sep:Nl)
+        fields (indent level)
+  | ( "headerTypeDeclaration",
+      [ []; [ "HEADER" ]; []; [ "{" ]; [ "}" ] ],
+      [ opt_annos; name; tparams; fields ] ) ->
+      F.fprintf fmt "%aheader %a%a {\n%a\n%s}"
+        (pp_opt_annos ~level ~sep:Nl)
+        opt_annos pp_case_v name
+        (pp_opt_v ~postfix:"" pp_case_v)
+        tparams
+        (pp_list_v ~level:(level + 1) ~sep:Nl)
+        fields (indent level)
+  | ( "typedefDeclaration",
+      [ []; [ "TYPEDEF" ]; []; [] ],
+      [ opt_annos; type_ref; name ] ) ->
+      F.fprintf fmt "%atypedef %a %a"
+        (pp_opt_annos ~level ~sep:Nl)
+        opt_annos pp_case_v type_ref pp_case_v name
+  | ( "typedefDeclaration",
+      [ []; [ "TYPEDEF" ]; []; [ "PHTM_12" ] ],
+      [ opt_annos; derived; name ] ) ->
+      F.fprintf fmt "%atypedef %a %a"
+        (pp_opt_annos ~level ~sep:Nl)
+        opt_annos (pp_syntax_decl ~level:0) derived pp_case_v name
+  | ( "typedefDeclaration",
+      [ []; [ "TYPE" ]; []; [] ],
+      [ opt_annos; type_ref; name ] ) ->
+      F.fprintf fmt "%atype %a %a"
+        (pp_opt_annos ~level ~sep:Nl)
+        opt_annos pp_case_v type_ref pp_case_v name
+  | "typeDeclaration", [ []; [ ";" ] ], [ typedef ] ->
+      F.fprintf fmt "%a;" (pp_syntax_decl ~level) typedef
+  | "typeDeclaration", [ []; [ ";"; "PHTM_13" ] ], [ parser_type_decl ] ->
+      F.fprintf fmt "%a;" (pp_syntax_parser_type_decl ~level) parser_type_decl
+  | "typeDeclaration", [ []; [ ";"; "PHTM_14" ] ], [ ctrl_type_decl ] ->
+      F.fprintf fmt "%a;" (pp_syntax_ctrl_typ_decl ~level) ctrl_type_decl
+  | "typeDeclaration", [ []; [ ";"; "PHTM_15" ] ], [ pckg_type_decl ] ->
+      F.fprintf fmt "%a;" (pp_syntax_pckg_type_decl ~level) pckg_type_decl
   | _ ->
       failwith
         (Printf.sprintf "@pp_syntax_decl: expected declaration, got %s"
@@ -1157,15 +1237,18 @@ and pp_case_v' fmt (value : value) : unit =
   (* Declarations *)
   | ( "variableDeclarationWithoutSemicolon",
       [ []; []; []; []; [] ],
-      [ opt_anno; type_ref; name; opt_init ] ) ->
+      [ opt_annos; type_ref; name; opt_init ] ) ->
       F.fprintf fmt "%a%a %a%a"
         (pp_opt_annos ~level:0 ~sep:SpaceSep)
-        opt_anno pp_case_v type_ref pp_case_v name
+        opt_annos pp_case_v type_ref pp_case_v name
         (pp_opt_v ~postfix:"" pp_case_v)
         opt_init
-  (* Transition statements *)
-  | "stateExpression", [ []; [ ";" ] ], [ name ] ->
-      F.fprintf fmt "%a;" pp_case_v name
+  | "specifiedIdentifier", [ []; []; [] ], [ name; init ] ->
+      F.fprintf fmt "%a%a" pp_case_v name pp_case_v init
+  | "structField", [ []; []; []; [ ";" ] ], [ opt_annos; type_ref; name ] ->
+      F.fprintf fmt "%a%a %a;"
+        (pp_opt_annos ~level:0 ~sep:SpaceSep)
+        opt_annos pp_case_v type_ref pp_case_v name
   | _ -> pp_default_case_v fmt value
 
 and pp_case_v fmt (value : value) : unit =
@@ -1175,7 +1258,7 @@ and pp_case_v fmt (value : value) : unit =
   | "functionDeclaration" | "actionDeclaration" | "parserDeclaration"
   | "controlDeclaration" | "valueSetDeclaration" | "headerTypeDeclaration"
   | "headerUnionDeclaration" | "structTypeDeclaration" | "enumDeclaration"
-  | "typeDeclaration" ->
+  | "typedefDeclaration" | "typeDeclaration" ->
       pp_syntax_decl ~level:0 fmt value
   | "nonTypeName" | "name" | "prefixedNonTypeName" | "prefixedType" ->
       pp_syntax_name fmt value
@@ -1215,7 +1298,8 @@ and pp_case_v fmt (value : value) : unit =
   | "controlTypeDeclaration" -> pp_syntax_ctrl_typ_decl ~level:0 fmt value
   | "selectCase" -> pp_syntax_select_case fmt value
   | "selectExpression" -> pp_syntax_select_expr ~level:0 fmt value
-  | "transitionStatement" -> pp_syntax_trans_stmt fmt value
+  | "stateExpression" -> pp_syntax_state_expr ~level:0 fmt value
+  | "transitionStatement" -> pp_syntax_trans_stmt ~level:0 fmt value
   | "parserBlockStatement" -> pp_syntax_parser_stmt ~level:0 fmt value
   | "parserState" -> pp_syntax_parser_state ~level:0 fmt value
   | "parserTypeDeclaration" -> pp_syntax_parser_type_decl ~level:0 fmt value

--- a/p4spec/lib/parsing/pp.ml
+++ b/p4spec/lib/parsing/pp.ml
@@ -83,7 +83,7 @@ and pp_list_v ?(level = 0) ~sep fmt (value : value) : unit =
   match id_of_list_v value with
   | "identifier" | "typeParameterList" | "parameter" | "expression" | "kvPair"
   | "simpleKeysetExpression" | "realTypeArg" | "typeArg" | "argument"
-  | "keyElement" | "action" | "entry" | "selectCase" | "specifiedIdentifier"
+  | "keyElement" | "entry" | "selectCase" | "specifiedIdentifier"
   | "structField" | "simpleAnnotation" ->
       pp_list ~level pp_case_v ~sep fmt values
   | "switchCase" -> pp_list ~level (pp_syntax_stmt' ~level) ~sep fmt values
@@ -96,6 +96,7 @@ and pp_list_v ?(level = 0) ~sep fmt (value : value) : unit =
   | "methodPrototype" -> pp_list ~level (pp_syntax_mthd ~level) ~sep fmt values
   | "objDeclaration" | "controlLocalDeclaration" | "parserLocalElement" ->
       pp_list ~level (pp_syntax_decl ~level) ~sep fmt values
+  | "action" -> pp_list ~level (pp_syntax_action ~level) ~sep fmt values
   | "tableProperty" ->
       pp_list ~level (pp_syntax_table_prop ~level) ~sep fmt values
   | "parserStatement" ->
@@ -284,11 +285,11 @@ and pp_syntax_nb_expr fmt (value : value) : unit =
   | "nonBraceExpression", [ [ "+" ]; [] ], [ arg ] ->
       F.fprintf fmt "+(%a)" pp_case_v arg
   | "nonBraceExpression", [ []; [ "." ]; [] ], [ typ; member ] ->
-      F.fprintf fmt "(%a).(%a)" pp_case_v typ pp_case_v member
+      F.fprintf fmt "%a.%a" pp_case_v typ pp_case_v member
   | "nonBraceExpression", [ [ "ERROR"; "." ]; [] ], [ member ] ->
-      F.fprintf fmt "error.(%a)" pp_case_v member
+      F.fprintf fmt "error.%a" pp_case_v member
   | "nonBraceExpression", [ []; [ "." ]; [ "PHTM_5" ] ], [ expr; member ] ->
-      F.fprintf fmt "(%a).(%a)" pp_case_v expr pp_case_v member
+      F.fprintf fmt "%a.%a" pp_case_v expr pp_case_v member
   | "nonBraceExpression", [ []; [ binop ]; [] ], [ arg1; arg2 ]
     when is_binary_op binop ->
       F.fprintf fmt "(%a) %s (%a)" pp_case_v arg1 binop pp_case_v arg2
@@ -300,19 +301,15 @@ and pp_syntax_nb_expr fmt (value : value) : unit =
   | ( "nonBraceExpression",
       [ []; [ "<" ]; [ ">"; "(" ]; [ ")" ] ],
       [ func; type_args; args ] ) ->
-      F.fprintf fmt "(%a)<%a>(%a)" pp_case_v func
+      F.fprintf fmt "%a<%a>(%a)" pp_case_v func
         (pp_list_v ~level:0 ~sep:Comma)
         type_args
         (pp_list_v ~level:0 ~sep:Comma)
         args
   | "nonBraceExpression", [ []; [ "(" ]; [ ")" ] ], [ func; args ] ->
-      F.fprintf fmt "(%a)(%a)" pp_case_v func
-        (pp_list_v ~level:0 ~sep:Comma)
-        args
+      F.fprintf fmt "%a(%a)" pp_case_v func (pp_list_v ~level:0 ~sep:Comma) args
   | "nonBraceExpression", [ []; [ "(" ]; [ ")"; "PHTM_6" ] ], [ typ; args ] ->
-      F.fprintf fmt "(%a)(%a)" pp_case_v typ
-        (pp_list_v ~level:0 ~sep:Comma)
-        args
+      F.fprintf fmt "%a(%a)" pp_case_v typ (pp_list_v ~level:0 ~sep:Comma) args
   | "nonBraceExpression", [ [ "(" ]; [ ")" ]; [] ], [ typ; expr ] ->
       F.fprintf fmt "(%a)(%a)" pp_case_v typ pp_case_v expr
   | "nonBraceExpression", _, _ ->
@@ -340,9 +337,9 @@ and pp_syntax_expr fmt (value : value) : unit =
   | "expression", [ []; []; [] ], [ dot; name ] ->
       F.fprintf fmt "%a%a" pp_case_v dot pp_case_v name
   | "expression", [ []; [ "[" ]; [ "]" ] ], [ array; index ] ->
-      F.fprintf fmt "(%a)[%a]" pp_case_v array pp_case_v index
+      F.fprintf fmt "%a[%a]" pp_case_v array pp_case_v index
   | "expression", [ []; [ "[" ]; [ ":" ]; [ "]" ] ], [ bits; hi; lo ] ->
-      F.fprintf fmt "(%a)[%a:%a]" pp_case_v bits pp_case_v hi pp_case_v lo
+      F.fprintf fmt "%a[%a:%a]" pp_case_v bits pp_case_v hi pp_case_v lo
   | "expression", [ [ "{" ]; []; [ "}" ] ], [ exprs; comma ] ->
       F.fprintf fmt "{ %a%a }"
         (pp_list_v ~level:0 ~sep:Comma)
@@ -373,11 +370,11 @@ and pp_syntax_expr fmt (value : value) : unit =
   | "expression", [ [ "(" ]; [ ")" ]; [] ], [ typ; expr ] ->
       F.fprintf fmt "(%a)(%a)" pp_case_v typ pp_case_v expr
   | "expression", [ []; [ "." ]; [] ], [ typ; name ] ->
-      F.fprintf fmt "(%a).(%a)" pp_case_v typ pp_case_v name
+      F.fprintf fmt "%a.%a" pp_case_v typ pp_case_v name
   | "expression", [ [ "ERROR"; "." ]; [] ], [ member ] ->
-      F.fprintf fmt "error.(%a)" pp_case_v member
+      F.fprintf fmt "error.%a" pp_case_v member
   | "expression", [ []; [ "." ]; [ "PHTM_5" ] ], [ expr; member ] ->
-      F.fprintf fmt "(%a).(%a)" pp_case_v expr pp_case_v member
+      F.fprintf fmt "%a.%a" pp_case_v expr pp_case_v member
   | "expression", [ []; [ binop ]; [] ], [ arg1; arg2 ] when is_binary_op binop
     ->
       F.fprintf fmt "(%a) %s (%a)" pp_case_v arg1 binop pp_case_v arg2
@@ -388,19 +385,15 @@ and pp_syntax_expr fmt (value : value) : unit =
   | ( "expression",
       [ []; [ "<" ]; [ ">"; "(" ]; [ ")" ] ],
       [ func; type_args; args ] ) ->
-      F.fprintf fmt "(%a)<%a>(%a)" pp_case_v func
+      F.fprintf fmt "%a<%a>(%a)" pp_case_v func
         (pp_list_v ~level:0 ~sep:Comma)
         type_args
         (pp_list_v ~level:0 ~sep:Comma)
         args
   | "expression", [ []; [ "(" ]; [ ")" ] ], [ func; args ] ->
-      F.fprintf fmt "(%a)(%a)" pp_case_v func
-        (pp_list_v ~level:0 ~sep:Comma)
-        args
+      F.fprintf fmt "%a(%a)" pp_case_v func (pp_list_v ~level:0 ~sep:Comma) args
   | "expression", [ []; [ "(" ]; [ ")"; "PHTM_6" ] ], [ typ; args ] ->
-      F.fprintf fmt "(%a)(%a)" pp_case_v typ
-        (pp_list_v ~level:0 ~sep:Comma)
-        args
+      F.fprintf fmt "%a(%a)" pp_case_v typ (pp_list_v ~level:0 ~sep:Comma) args
   | "expression", _, _ ->
       failwith
         (F.asprintf "@pp_syntax_expr: ill-formed expression:\n%a" pp_case_v
@@ -580,7 +573,7 @@ and pp_syntax_stmt ~level fmt (value : value) : unit =
   | "emptyStatement", [ [ ";" ] ], [] -> F.fprintf fmt ";"
   | "blockStatement", [ []; [ "{" ]; [ "}" ] ], [ opt_annos; stmts ] ->
       F.fprintf fmt "%a{\n%a\n%s}"
-        (pp_opt_annos ~level ~sep:SpaceSep)
+        (pp_opt_annos ~level ~sep:Nl)
         opt_annos
         (pp_list_v ~level:(level + 1) ~sep:Nl)
         stmts (indent level)
@@ -749,11 +742,11 @@ and pp_syntax_action_ref fmt (value : value) : unit =
         (Printf.sprintf "@pp_syntax_action_ref: expected action ref, got %s"
            (id_of_case_v value))
 
-and pp_syntax_action fmt (value : value) : unit =
+and pp_syntax_action ~level fmt (value : value) : unit =
   match flatten_case_v value with
   | "action", [ []; []; [ ";" ] ], [ opt_annos; action_ref ] ->
       F.fprintf fmt "%a%a;"
-        (pp_opt_annos ~level:0 ~sep:SpaceSep)
+        (pp_opt_annos ~level ~sep:Nl)
         opt_annos pp_case_v action_ref
   | "action", _, _ ->
       failwith
@@ -1078,7 +1071,7 @@ and pp_syntax_decl ~level fmt (value : value) : unit =
   | ( "instantiation",
       [ []; []; [ "(" ]; [ ")" ]; []; [ ";" ] ],
       [ opt_annos; type_ref; args; name; init ] ) ->
-      F.fprintf fmt "%a%a(%a) %a%a"
+      F.fprintf fmt "%a%a(%a) %a%a;"
         (pp_opt_annos ~level ~sep:Nl)
         opt_annos pp_case_v type_ref
         (pp_list_v ~level:0 ~sep:Comma)
@@ -1117,19 +1110,19 @@ and pp_syntax_decl ~level fmt (value : value) : unit =
   | ( "valueSetDeclaration",
       [ []; [ "VALUESET"; "<" ]; [ ">"; "(" ]; [ ")" ]; [ ";" ] ],
       [ opt_annos; base_type; size; name ] ) ->
-      F.fprintf fmt "%avalueset<%a>(%a) %a"
+      F.fprintf fmt "%avalue_set<%a>(%a) %a;"
         (pp_opt_annos ~level ~sep:Nl)
         opt_annos pp_case_v base_type pp_case_v size pp_case_v name
   | ( "valueSetDeclaration",
       [ []; [ "VALUESET"; "<" ]; [ ">"; "(" ]; [ ")" ]; [ ";"; "PHTM_17" ] ],
       [ opt_annos; tuple; size; name ] ) ->
-      F.fprintf fmt "%avalueset<%a>(%a) %a"
+      F.fprintf fmt "%avalue_set<%a>(%a) %a;"
         (pp_opt_annos ~level ~sep:Nl)
         opt_annos pp_case_v tuple pp_case_v size pp_case_v name
   | ( "valueSetDeclaration",
       [ []; [ "VALUESET"; "<" ]; [ ">"; "(" ]; [ ")" ]; [ ";"; "PHTM_18" ] ],
       [ opt_annos; type_name; size; name ] ) ->
-      F.fprintf fmt "%avalueset<%a>(%a) %a"
+      F.fprintf fmt "%avalue_set<%a>(%a) %a;"
         (pp_opt_annos ~level ~sep:Nl)
         opt_annos pp_case_v type_name pp_case_v size pp_case_v name
   | ( "parserDeclaration",
@@ -1275,7 +1268,7 @@ and pp_syntax_anno_token fmt (value : value) : unit =
   | "annotationToken", [ [ "TUPLE" ] ], [] -> F.fprintf fmt "tuple"
   | "annotationToken", [ [ "TYPEDEF" ] ], [] -> F.fprintf fmt "typedef"
   | "annotationToken", [ [ "VARBIT" ] ], [] -> F.fprintf fmt "varbit"
-  | "annotationToken", [ [ "VALUESET" ] ], [] -> F.fprintf fmt "valueset"
+  | "annotationToken", [ [ "VALUESET" ] ], [] -> F.fprintf fmt "value_set"
   | "annotationToken", [ [ "LIST" ] ], [] -> F.fprintf fmt "list"
   | "annotationToken", [ [ "VOID" ] ], [] -> F.fprintf fmt "void"
   | "annotationToken", [ [ "_" ] ], [] -> F.fprintf fmt "_"
@@ -1381,7 +1374,7 @@ and pp_opt_annos ?(level = 0) ~sep fmt (value : value) : unit =
 and pp_case_v' fmt (value : value) : unit =
   match flatten_case_v value with
   (* Misc *)
-  | "trailingComma", [ [ "," ]; [ "PHTM_0" ] ], [] -> F.fprintf fmt ","
+  | "trailingComma", [ [ ","; "PHTM_0" ] ], [] -> F.fprintf fmt ","
   | "const", [ [ "CONST" ] ], [] -> F.fprintf fmt "const"
   (* Numbers *)
   | "number", [ []; [ "PHTM_1" ] ], [ value_int ] ->
@@ -1399,7 +1392,7 @@ and pp_case_v' fmt (value : value) : unit =
   | "typeOrVoid", [ [ "VOID" ] ], [] -> F.fprintf fmt "void"
   (* Key value pair *)
   | "kvPair", [ []; [ "=" ]; [] ], [ key; value ] ->
-      F.fprintf fmt "(%a) = (%a)" pp_case_v key pp_case_v value
+      F.fprintf fmt "%a = %a" pp_case_v key pp_case_v value
   (* Declarations *)
   | ( "variableDeclarationWithoutSemicolon",
       [ []; []; []; []; [] ],
@@ -1460,7 +1453,7 @@ and pp_case_v fmt (value : value) : unit =
   | "methodPrototype" -> pp_syntax_mthd ~level:0 fmt value
   | "keyElement" -> pp_syntax_key fmt value
   | "actionRef" -> pp_syntax_action_ref fmt value
-  | "action" -> pp_syntax_action fmt value
+  | "action" -> pp_syntax_action ~level:0 fmt value
   | "entryPriority" -> pp_syntax_entry_prio fmt value
   | "entry" -> pp_syntax_entry fmt value
   | "tableProperty" -> pp_syntax_table_prop ~level:0 fmt value

--- a/p4spec/lib/parsing/pp.ml
+++ b/p4spec/lib/parsing/pp.ml
@@ -62,7 +62,7 @@ and pp_value fmt (value : value) : unit =
   | ListV [] -> F.fprintf fmt ""
   | ListV values ->
       F.fprintf fmt "%s"
-        (String.concat "; "
+        (String.concat ", "
            (List.map (fun v -> F.asprintf "%a" pp_value v) values))
   | _ -> failwith "@pp_value: TODO"
 
@@ -105,11 +105,95 @@ and pp_syntax_name fmt (value : value) : unit =
   | "nonTypeName", [ [ "ENTRIES" ] ], [] -> F.fprintf fmt "entries"
   | "nonTypeName", [ [ "TYPE" ] ], [] -> F.fprintf fmt "type"
   | "nonTypeName", [ [ "PRIORITY" ] ], [] -> F.fprintf fmt "priority"
+  | "prefixedNonTypeName", [ []; []; [] ], [ dot; non_type_name ] ->
+      F.fprintf fmt "%a%a" pp_case_v dot pp_syntax_name non_type_name
+  | "prefixedType", [ []; []; [] ], [ dot; tid ] ->
+      F.fprintf fmt "%a%a" pp_case_v dot pp_syntax_tid tid
   | "name", [ [ "LIST" ] ], [] -> F.fprintf fmt "list"
   | _ ->
       failwith
         (Printf.sprintf "@pp_syntax_name: expected name, got %s"
            (id_of_case_v value))
+
+and pp_syntax_dir fmt (value : value) : unit =
+  match flatten_case_v value with
+  | "direction", [ [ "IN" ] ], [] -> F.fprintf fmt "in"
+  | "direction", [ [ "OUT" ] ], [] -> F.fprintf fmt "out"
+  | "direction", [ [ "INOUT" ] ], [] -> F.fprintf fmt "inout"
+  | "direction", [ [ "NONE" ] ], [] -> F.fprintf fmt ""
+  | "direction", _, _ ->
+      failwith
+        (F.asprintf "@pp_syntax_dir: ill-formed direction:\n%a" pp_case_v value)
+  | _ ->
+      failwith
+        (Printf.sprintf "@pp_syntax_dir: expected direction, got %s"
+           (id_of_case_v value))
+
+and pp_syntax_type fmt (value : value) : unit =
+  match flatten_case_v value with
+  | "baseType", [ [ "BOOL" ] ], [] -> F.fprintf fmt "bool"
+  | "baseType", [ [ "MATCH_KIND" ] ], [] -> F.fprintf fmt "match_kind"
+  | "baseType", [ [ "ERROR" ] ], [] -> F.fprintf fmt "error"
+  | "baseType", [ [ "BIT" ] ], [] -> F.fprintf fmt "bit"
+  | "baseType", [ [ "STRING" ] ], [] -> F.fprintf fmt "string"
+  | "baseType", [ [ "INT" ] ], [] -> F.fprintf fmt "int"
+  | "baseType", [ [ "BIT"; "<" ]; [ ">" ] ], [ value_int ] ->
+      F.fprintf fmt "bit<%a>" pp_value value_int
+  | "baseType", [ [ "INT"; "<" ]; [ ">" ] ], [ value_int ] ->
+      F.fprintf fmt "int<%a>" pp_value value_int
+  | "baseType", [ [ "VARBIT"; "<" ]; [ ">" ] ], [ value_int ] ->
+      F.fprintf fmt "varbit<%a>" pp_value value_int
+  | "baseType", [ [ "BIT"; "<"; "(" ]; [ ")"; ">" ] ], [ expr ] ->
+      F.fprintf fmt "bit<(%a)>" pp_syntax_expr expr
+  | "baseType", [ [ "INT"; "<"; "(" ]; [ ")"; ">" ] ], [ expr ] ->
+      F.fprintf fmt "int<(%a)>" pp_syntax_expr expr
+  | "baseType", [ [ "VARBIT"; "<"; "(" ]; [ ")"; ">" ] ], [ expr ] ->
+      F.fprintf fmt "varbit<(%a)>" pp_syntax_expr expr
+  | "baseType", _, _ ->
+      failwith
+        (F.asprintf "@pp_syntax_type: ill-formed base type:\n%a" pp_case_v value)
+  | "specializedType", [ []; [ "<" ]; [ ">" ] ], [ type_name; type_arg_list ] ->
+      F.fprintf fmt "%a<%a>" pp_syntax_name type_name pp_value type_arg_list
+  | "specializedType", _, _ ->
+      failwith
+        (F.asprintf "@pp_syntax_type: ill-formed specialized type:\n%a"
+           pp_case_v value)
+  | "headerStackType", [ []; [ "[" ]; [ "]" ] ], [ type_name; expr ] ->
+      F.fprintf fmt "%a[%a]" pp_syntax_name type_name pp_syntax_expr expr
+  | "headerStackType", [ []; [ "[" ]; [ "]"; "PHTM_16" ] ], [ spec_type; expr ]
+    ->
+      F.fprintf fmt "%a[%a]" pp_syntax_type spec_type pp_syntax_expr expr
+  | "headerStackType", _, _ ->
+      failwith
+        (F.asprintf "@pp_syntax_type: ill-formed header stack type:\n%a"
+           pp_case_v value)
+  | "listType", [ [ "LIST"; "<" ]; [ ">" ] ], [ type_arg ] ->
+      F.fprintf fmt "list<%a>" pp_syntax_type_arg type_arg
+  | "listType", _, _ ->
+      failwith
+        (F.asprintf "@pp_syntax_type: ill-formed list type:\n%a" pp_case_v value)
+  | "tupleType", [ [ "TUPLE"; "<" ]; [ ">" ] ], [ type_arg_list ] ->
+      F.fprintf fmt "tuple<%a>" pp_value type_arg_list
+  | "tupleType", _, _ ->
+      failwith
+        (F.asprintf "@pp_syntax_type: ill-formed tuple type:\n%a" pp_case_v
+           value)
+  | _ ->
+      failwith
+        (Printf.sprintf "@pp_syntax_type: expected type, got %s"
+           (id_of_case_v value))
+
+and pp_syntax_expr _fmt (value : value) : unit =
+  match flatten_case_v value with
+  | _ -> failwith "@pp_syntax_expr: not yet implemented"
+
+and pp_syntax_type_arg _fmt (value : value) : unit =
+  match flatten_case_v value with
+  | _ -> failwith "@pp_syntax_type_arg: not yet implemented"
+
+and pp_syntax_stmt _fmt (value : value) : unit =
+  match flatten_case_v value with
+  | _ -> failwith "@pp_syntax_stmt: not yet implemented"
 
 and pp_syntax_mthd fmt (value : value) : unit =
   match flatten_case_v value with
@@ -149,7 +233,10 @@ and pp_syntax_decls ~level fmt (value : value) : unit =
 
 and pp_syntax_decl ~level fmt (value : value) : unit =
   match flatten_case_v value with
-  | "constantDeclaration", _, _
+  | ( "constantDeclaration",
+      [ []; [ "CONST" ]; []; []; [ ";" ] ],
+      [ _optAnnotations; _typeRef; _name; _init ] ) ->
+      F.fprintf fmt ""
   | "errorDeclaration", _, _
   | "matchKindDeclaration", _, _
   | ( "externDeclaration",
@@ -194,13 +281,22 @@ and pp_syntax_decl ~level fmt (value : value) : unit =
 
 and pp_case_v' fmt (value : value) : unit =
   match flatten_case_v value with
+  (* Misc *)
+  | "trailingComma", [ [ "," ]; [ "PHTM_0" ] ], [] -> F.fprintf fmt ","
+  | "const", [ [ "CONST" ] ], [] -> F.fprintf fmt "const"
+  (* Numbers *)
   | "number", [ []; [ "PHTM_1" ] ], [ value_int ] ->
       F.fprintf fmt "%a" pp_value value_int
+  | "number", [ []; [ "S" ]; [] ], [ value_width; value_int ] ->
+      F.fprintf fmt "%as%a" pp_value value_width pp_value value_int
+  | "number", [ []; [ "W" ]; [] ], [ value_width; value_int ] ->
+      F.fprintf fmt "%aw%a" pp_value value_width pp_value value_int
+  (* Strings *)
   | "stringLiteral", [ []; [ "PHTM_2" ] ], [ value_text ] ->
       pp_value fmt value_text
+  (* Names *)
+  | "dotPrefix", [ [ "." ] ], [] -> F.fprintf fmt "."
   | "direction", [ [ "NONE" ] ], [] -> F.fprintf fmt ""
-  | "baseType", [ [ "INT"; "<" ]; [ ">" ] ], [ value_int ] ->
-      F.fprintf fmt "%a" pp_value value_int
   | _ -> pp_default_case_v fmt value
 
 and pp_case_v fmt (value : value) : unit =
@@ -211,7 +307,8 @@ and pp_case_v fmt (value : value) : unit =
   | "headerTypeDeclaration" | "headerUnionDeclaration" | "structTypeDeclaration"
   | "enumDeclaration" | "typeDeclaration" ->
       pp_syntax_decl ~level:0 fmt value
-  | "nonTypeName" | "name" -> pp_syntax_name fmt value
+  | "nonTypeName" | "name" | "prefixedNonTypeName" -> pp_syntax_name fmt value
   | "typeIdentifier" -> pp_syntax_tid fmt value
   | "identifier" -> pp_syntax_id fmt value
+  | "direction" -> pp_syntax_dir fmt value
   | _ -> pp_case_v' fmt value

--- a/p4spec/lib/parsing/pp.ml
+++ b/p4spec/lib/parsing/pp.ml
@@ -395,16 +395,69 @@ and pp_syntax_keyset_expr fmt (value : value) : unit =
         (F.asprintf
            "@pp_syntax_keyset_expr: ill-formed tuple keyset expression:\n%a"
            pp_case_v value)
-  | _ -> failwith "@pp_syntax_keyset_expr: not yet implemented"
+  | _ ->
+      failwith
+        (Printf.sprintf
+           "@pp_syntax_keyset_expr: expected keyset expression, got %s"
+           (id_of_case_v value))
 
-and pp_syntax_type_arg _fmt (value : value) : unit =
+and pp_syntax_targ fmt (value : value) : unit =
   match flatten_case_v value with
-  | _ -> failwith "@pp_syntax_type_arg: not yet implemented"
+  | "realTypeArg", [ [ "VOID" ] ], [] -> F.fprintf fmt "void"
+  | "realTypeArg", [ [ "_" ] ], [] -> F.fprintf fmt "_"
+  | "realTypeArg", _, _ ->
+      failwith
+        (F.asprintf "@pp_syntax_targ: ill-formed real type argument:\n%a"
+           pp_case_v value)
+  | "typeArg", [ [ "VOID" ] ], [] -> F.fprintf fmt "void"
+  | "typeArg", [ [ "_" ] ], [] -> F.fprintf fmt "_"
+  | "typeArg", _, _ ->
+      failwith
+        (F.asprintf "@pp_syntax_targ: ill-formed type argument:\n%a" pp_case_v
+           value)
+  | _ ->
+      failwith
+        (Printf.sprintf "@pp_syntax_targ: expected type argument, got %s"
+           (id_of_case_v value))
+
+and pp_syntax_arg fmt (value : value) : unit =
+  match flatten_case_v value with
+  | "argument", [ []; [ "=" ]; [] ], [ name; expr ] ->
+      F.fprintf fmt "%a = (%a)" pp_case_v name pp_case_v expr
+  | "argument", [ [ "_" ] ], [] -> F.fprintf fmt "_"
+  | "argument", [ []; [ "="; "_" ] ], [ name ] ->
+      F.fprintf fmt "%a = _" pp_case_v name
+  | "argument", _, _ ->
+      failwith
+        (F.asprintf "@pp_syntax_arg: ill-formed argument:\n%a" pp_case_v value)
+  | _ ->
+      failwith
+        (Printf.sprintf "@pp_syntax_arg: expected argument, got %s"
+           (id_of_case_v value))
+
+and pp_syntax_lvalue fmt (value : value) : unit =
+  match flatten_case_v value with
+  | "lvalue", [ [ "THIS" ] ], [] -> F.fprintf fmt "this"
+  | "lvalue", [ []; [ "." ]; [] ], [ expr; name ] ->
+      F.fprintf fmt "%a.%a" pp_case_v expr pp_case_v name
+  | "lvalue", [ []; [ "[" ]; [ "]" ] ], [ array; index ] ->
+      F.fprintf fmt "%a[%a]" pp_case_v array pp_case_v index
+  | "lvalue", [ []; [ "[" ]; [ ":" ]; [ "]" ] ], [ bits; hi; lo ] ->
+      F.fprintf fmt "%a[%a:%a]" pp_case_v bits pp_case_v hi pp_case_v lo
+  | "lvalue", [ [ "(" ]; [ ")" ] ], [ lvalue ] ->
+      F.fprintf fmt "(%a)" pp_case_v lvalue
+  | "lvalue", _, _ ->
+      failwith
+        (F.asprintf "@pp_syntax_lvalue: ill-formed l-value:\n%a" pp_case_v value)
+  | _ ->
+      failwith
+        (Printf.sprintf "@pp_syntax_lvalue: expected l-value, got %s"
+           (id_of_case_v value))
 
 and pp_syntax_init fmt (value : value) : unit =
   match flatten_case_v value with
   | "initializer", [ [ "=" ]; [] ], [ expr ] ->
-      F.fprintf fmt " = %a" pp_syntax_expr expr
+      F.fprintf fmt " = (%a)" pp_syntax_expr expr
   | "initializer", _, _ ->
       failwith
         (F.asprintf "@pp_syntax_init: ill-formed initializer:\n%a" pp_case_v
@@ -548,4 +601,7 @@ and pp_case_v fmt (value : value) : unit =
   | "simpleKeysetExpression" | "reducedSimpleKeysetExpression"
   | "tupleKeysetExpression" ->
       pp_syntax_keyset_expr fmt value
+  | "realTypeArg" | "typeArg" -> pp_syntax_targ fmt value
+  | "argument" -> pp_syntax_arg fmt value
+  | "lvalue" -> pp_syntax_lvalue fmt value
   | _ -> pp_case_v' fmt value

--- a/p4spec/lib/parsing/pp.ml
+++ b/p4spec/lib/parsing/pp.ml
@@ -66,46 +66,50 @@ and pp_text_v ~escaped fmt (value : value) : unit =
 
 and pp_case_v fmt (value : value) : unit =
   match id_of_case_v value with
-  | "constantDeclaration" | "variableDeclarationWithoutSemicolon"
-  | "variableDeclaration" | "errorDeclaration" | "matchKindDeclaration"
-  | "externDeclaration" | "instantiation" | "functionDeclaration"
-  | "actionDeclaration" | "parserDeclaration" | "controlTypeDeclaration"
-  | "controlDeclaration" | "valueSetDeclaration" | "headerTypeDeclaration"
-  | "headerUnionDeclaration" | "structTypeDeclaration" | "parserTypeDeclaration"
-  | "enumDeclaration" | "typedefDeclaration" | "typeDeclaration"
-  | "packageTypeDeclaration" ->
-      pp_syntax_decl ~level:0 fmt value
+  (* Misc *)
   | "trailingComma" -> pp_syntax_comma fmt value
   | "const" -> pp_syntax_const fmt value
+  (* Numbers *)
   | "number" -> pp_syntax_num fmt value
+  (* Strings *)
   | "stringLiteral" -> pp_syntax_str fmt value
+  (* Names *)
+  | "identifier" -> pp_syntax_id fmt value
+  | "typeIdentifier" -> pp_syntax_tid fmt value
   | "dotPrefix" | "nonTypeName" | "name" | "prefixedNonTypeName"
   | "prefixedType" ->
       pp_syntax_name fmt value
-  | "typeIdentifier" -> pp_syntax_tid fmt value
-  | "identifier" -> pp_syntax_id fmt value
+  (* Directions *)
   | "direction" -> pp_syntax_dir fmt value
+  (* Types *)
   | "baseType" | "specializedType" | "headerStackType" | "listType"
   | "tupleType" | "typeOrVoid" ->
       pp_syntax_type fmt value
+  (* Type parameters, parameters, constructor parameters *)
   | "typeParameters" -> pp_syntax_tparams fmt value
   | "parameter" | "constructorParameters" -> pp_syntax_params fmt value
+  (* Expressions *)
   | "nonBraceExpression" -> pp_syntax_nb_expr fmt value
   | "expression" -> pp_syntax_expr fmt value
+  (* Keyset expressions *)
   | "simpleKeysetExpression" | "reducedSimpleKeysetExpression"
   | "tupleKeysetExpression" ->
       pp_syntax_keyset_expr fmt value
+  (* Expression key-value pairs *)
   | "kvPair" -> pp_syntax_kvpair fmt value
+  (* Type arguments *)
   | "realTypeArg" | "typeArg" -> pp_syntax_targ fmt value
+  (* Arguments *)
   | "argument" -> pp_syntax_arg fmt value
+  (* L-values *)
   | "lvalue" -> pp_syntax_lvalue fmt value
+  (* Statements and declarations *)
   | "initializer" -> pp_syntax_init fmt value
-  | "assignmentOrMethodCallStatementWithoutSemicolon" | "switchLabel"
-  | "switchCase" | "forCollectionExpr"
-  | "assignmentOrMethodCallStatement" | "directApplication"
-  | "conditionalStatement" | "emptyStatement" | "blockStatement"
-  | "returnStatement" | "breakStatement" | "continueStatement" | "exitStatement"
-  | "switchStatement" | "forStatement" ->
+  | "assignmentOrMethodCallStatementWithoutSemicolon"
+  | "assignmentOrMethodCallStatement" | "directApplication" | "conditionalStatement"
+  | "emptyStatement" | "blockStatement" | "returnStatement" | "breakStatement"
+  | "continueStatement" | "exitStatement" | "switchLabel" | "switchCase"
+  | "switchStatement" | "forCollectionExpr" | "forStatement" ->
       pp_syntax_stmt ~level:0 fmt value
   | "functionPrototype" -> pp_syntax_func fmt value
   | "methodPrototype" -> pp_syntax_mthd ~level:0 fmt value
@@ -120,9 +124,20 @@ and pp_case_v fmt (value : value) : unit =
   | "stateExpression" -> pp_syntax_state_expr ~level:0 fmt value
   | "transitionStatement" -> pp_syntax_trans_stmt ~level:0 fmt value
   | "parserBlockStatement" -> pp_syntax_parser_stmt ~level:0 fmt value
+  | "variableDeclarationWithoutSemicolon" | "variableDeclaration"
+  | "constantDeclaration" | "errorDeclaration" | "matchKindDeclaration"
+  | "externDeclaration" | "instantiation" | "functionDeclaration"
+  | "actionDeclaration" | "parserDeclaration" | "typeDeclaration"
+  | "controlDeclaration" | "headerTypeDeclaration"
+  | "headerUnionDeclaration" | "structTypeDeclaration" | "enumDeclaration"
+  | "typedefDeclaration" | "parserTypeDeclaration" | "controlTypeDeclaration"
+  | "packageTypeDeclaration" | "valueSetDeclaration"
+  ->
+      pp_syntax_decl ~level:0 fmt value
   | "parserState" -> pp_syntax_parser_state ~level:0 fmt value
   | "specifiedIdentifier" -> pp_syntax_spec_id fmt value
   | "structField" -> pp_syntax_struct_field fmt value
+  (* Annotations *)
   | "annotationToken" -> pp_syntax_anno_token fmt value
   | "simpleAnnotation" | "structuredAnnotationBody" ->
       pp_syntax_anno_body fmt value
@@ -163,28 +178,35 @@ and pp_list_v ?(level = 0) ~sep fmt (value : value) : unit =
           (F.asprintf "@pp_list_v: expected ListV, got %a" pp_value value)
   in
   match id_of_list_v value with
-  | "identifier" | "typeParameterList" | "parameter" | "expression" | "kvPair"
-  | "simpleKeysetExpression" | "realTypeArg" | "typeArg" | "argument"
-  | "keyElement" | "entry" | "selectCase" | "specifiedIdentifier"
-  | "structField" | "simpleAnnotation" ->
+  | "name" | "parameter" | "expression" | "simpleKeysetExpression"
+  | "kvPair" | "realTypeArg" | "typeArg" | "argument" ->
       pp_list ~level pp_case_v ~sep fmt values
   | "switchCase" -> pp_list ~level (pp_syntax_stmt ~level) ~sep fmt values
   | "declOrAssignmentOrMethodCallStatement" ->
       pp_list pp_syntax_decl_or_assign_or_call_stmt ~sep fmt values
-  | "assignmentOrMethodCallStatement" ->
-      pp_list (pp_syntax_stmt ~level:0) ~sep fmt values
+  | "assignmentOrMethodCallStatementWithoutSemicolon" ->
+      pp_list pp_syntax_decl_or_assign_or_call_stmt ~sep fmt values
   | "statementOrDeclaration" ->
-      pp_list ~level (pp_syntax_stat_or_decl ~level) ~sep fmt values
+      pp_list ~level (pp_syntax_stmt_or_decl ~level) ~sep fmt values
   | "methodPrototype" -> pp_list ~level (pp_syntax_mthd ~level) ~sep fmt values
-  | "objDeclaration" | "controlLocalDeclaration" | "parserLocalElement" ->
-      pp_list ~level (pp_syntax_decl ~level) ~sep fmt values
+  | "objDeclaration" -> pp_list ~level (pp_syntax_decl ~level) ~sep fmt values
+  | "keyElement" -> pp_list ~level pp_case_v ~sep fmt values
   | "action" -> pp_list ~level (pp_syntax_action ~level) ~sep fmt values
+  | "entry" -> pp_list ~level pp_case_v ~sep fmt values
   | "tableProperty" ->
       pp_list ~level (pp_syntax_table_prop ~level) ~sep fmt values
+  | "controlLocalDeclaration" ->
+      pp_list ~level (pp_syntax_decl ~level) ~sep fmt values
+  | "selectCase" -> pp_list ~level pp_case_v ~sep fmt values
   | "parserStatement" ->
       pp_list ~level (pp_syntax_parser_stmt ~level) ~sep fmt values
   | "parserState" ->
       pp_list ~level (pp_syntax_parser_state ~level) ~sep fmt values
+  | "parserLocalElement" ->
+      pp_list ~level (pp_syntax_decl ~level) ~sep fmt values
+  | "specifiedIdentifier"
+  | "structField" | "simpleAnnotation" ->
+      pp_list ~level pp_case_v ~sep fmt values
   | "annotation" -> pp_list_no_start_indent ~level pp_case_v ~sep fmt values
   | "declaration" when List.compare_length_with values 0 = 0 ->
       F.fprintf fmt ";"
@@ -698,7 +720,7 @@ and pp_syntax_lvalue fmt (value : value) : unit =
 
 (** Statements and declarations **)
 
-(* Initializers *)
+(* Variable and constant declarations *)
 
 and pp_syntax_init fmt (value : value) : unit =
   match flatten_case_v value with
@@ -713,7 +735,7 @@ and pp_syntax_init fmt (value : value) : unit =
         (Printf.sprintf "@pp_syntax_init: expected initializer, got %s"
            (id_of_case_v value))
 
-(* Statements in for init statements *)
+(* For statements *)
 
 and pp_syntax_decl_or_assign_or_call_stmt fmt (value : value) : unit =
   match id_of_case_v value with
@@ -726,24 +748,6 @@ and pp_syntax_decl_or_assign_or_call_stmt fmt (value : value) : unit =
            "@pp_syntax_decl_or_assign_or_call_stmt: expected variable \
             declaration, assignment statement, or method call statement, got \
             %s"
-           (id_of_case_v value))
-
-(* Statements or declarations in block statements *)
-
-and pp_syntax_stat_or_decl ~level fmt (value : value) : unit =
-  match id_of_case_v value with
-  | "variableDeclaration" | "constantDeclaration" ->
-      pp_syntax_decl ~level fmt value
-  | "assignmentOrMethodCallStatement" | "directApplication"
-  | "conditionalStatement" | "emptyStatement" | "blockStatement"
-  | "returnStatement" | "breakStatement" | "continueStatement" | "exitStatement"
-  | "switchStatement" | "forStatement" ->
-      pp_syntax_stmt ~level fmt value
-  | _ ->
-      failwith
-        (Printf.sprintf
-           "@pp_syntax_stat_or_decl: expected variable declaration, constant \
-            declaration, or statement, got %s"
            (id_of_case_v value))
 
 (* Statements *)
@@ -850,7 +854,24 @@ and pp_syntax_stmt ~level fmt (value : value) : unit =
         (Printf.sprintf "@pp_syntax_stmt: expected statement, got %s"
            (id_of_case_v value))
 
-(* Function prototypes *)
+and pp_syntax_stmt_or_decl ~level fmt (value : value) : unit =
+  match id_of_case_v value with
+  | "variableDeclaration" | "constantDeclaration" ->
+      pp_syntax_decl ~level fmt value
+  | "assignmentOrMethodCallStatement" | "directApplication"
+  | "conditionalStatement" | "emptyStatement" | "blockStatement"
+  | "returnStatement" | "breakStatement" | "continueStatement" | "exitStatement"
+  | "switchStatement" | "forStatement" ->
+      pp_syntax_stmt ~level fmt value
+  | _ ->
+      failwith
+        (Printf.sprintf
+           "@pp_syntax_stmt_or_decl: expected variable declaration, constant \
+            declaration, or statement, got %s"
+           (id_of_case_v value))
+
+
+(* Extern declarations *)
 
 and pp_syntax_func fmt (value : value) : unit =
   match flatten_case_v value with
@@ -870,8 +891,6 @@ and pp_syntax_func fmt (value : value) : unit =
       failwith
         (Printf.sprintf "@pp_syntax_func: expected function prototype, got %s"
            (id_of_case_v value))
-
-(* Method prototypes *)
 
 and pp_syntax_mthd ~level fmt (value : value) : unit =
   match flatten_case_v value with
@@ -918,7 +937,7 @@ and pp_syntax_obj_init ~level fmt (value : value) : unit =
            "@pp_syntax_obj_init: expected object initializer, got %s"
            (id_of_case_v value))
 
-(* Table key elements *)
+(* Table key property *)
 
 and pp_syntax_key fmt (value : value) : unit =
   match flatten_case_v value with
@@ -937,7 +956,7 @@ and pp_syntax_key fmt (value : value) : unit =
         (Printf.sprintf "@pp_syntax_key: expected key element, got %s"
            (id_of_case_v value))
 
-(* Table actions *)
+(* Table actions property *)
 
 and pp_syntax_action_ref fmt (value : value) : unit =
   match flatten_case_v value with
@@ -966,7 +985,7 @@ and pp_syntax_action ~level fmt (value : value) : unit =
         (Printf.sprintf "@pp_syntax_action: expected action, got %s"
            (id_of_case_v value))
 
-(* Table entries *)
+(* Table entry property *)
 
 and pp_syntax_entry_prio fmt (value : value) : unit =
   match flatten_case_v value with
@@ -1168,7 +1187,7 @@ and pp_syntax_parser_state ~level fmt (value : value) : unit =
         (Printf.sprintf "@pp_syntax_parser_state: expected parser state, got %s"
            (id_of_case_v value))
 
-(* Specified identifiers for enum declarations *)
+(* Enum type declaration *)
 
 and pp_syntax_spec_id fmt (value : value) : unit =
   match flatten_case_v value with
@@ -1184,7 +1203,7 @@ and pp_syntax_spec_id fmt (value : value) : unit =
            "@pp_syntax_spec_id: expected specified identifier, got %s"
            (id_of_case_v value))
 
-(* Struct fields *)
+(* Struct, header, and union type declarations *)
 
 and pp_syntax_struct_field fmt (value : value) : unit =
   match flatten_case_v value with
@@ -1201,7 +1220,7 @@ and pp_syntax_struct_field fmt (value : value) : unit =
         (Printf.sprintf "@pp_syntax_struct_field: expected struct field, got %s"
            (id_of_case_v value))
 
-(* Declarations *)
+(* Declaration *)
 
 and pp_syntax_decl ~level fmt (value : value) : unit =
   match flatten_case_v value with
@@ -1436,7 +1455,7 @@ and pp_syntax_decl ~level fmt (value : value) : unit =
         (Printf.sprintf "@pp_syntax_decl: expected declaration, got %s"
            (id_of_case_v value))
 
-(* Annotations *)
+(** Annotations **)
 
 and pp_syntax_anno_token fmt (value : value) : unit =
   match flatten_case_v value with

--- a/p4spec/lib/parsing/pp.ml
+++ b/p4spec/lib/parsing/pp.ml
@@ -57,19 +57,32 @@ and pp_value fmt (value : value) : unit =
       F.fprintf fmt "(%s)"
         (String.concat ", "
            (List.map (fun v -> F.asprintf "%a" pp_value v) values))
-  | OptV (Some v) -> F.fprintf fmt "%a" pp_value v
-  | OptV None -> F.fprintf fmt ""
-  | ListV [] -> F.fprintf fmt ""
-  | ListV values ->
-      F.fprintf fmt "%s"
-        (String.concat ", "
-           (List.map (fun v -> F.asprintf "%a" pp_value v) values))
+  | OptV _ -> pp_opt_v fmt value
+  | ListV _ -> pp_list_v fmt value
   | _ -> failwith "@pp_value: TODO"
 
 and pp_text_v fmt (value : value) : unit =
   match value.it with
   | TextV text -> F.fprintf fmt "%s" text
   | _ -> failwith "@pp_text_v: expected TextV value"
+
+and pp_opt_v ?(postfix = "") fmt (value : value) : unit =
+  match value.it with
+  | OptV (Some v) -> F.fprintf fmt "%a%s" pp_value v postfix
+  | OptV None -> F.fprintf fmt ""
+  | _ -> failwith "@pp_opt_v: expected OptV value"
+
+and pp_list_v ?(sep = Comma) fmt (value : value) : unit =
+  match (id_of_list_v value, value.it) with
+  | "declaration", ListV [] -> F.fprintf fmt ";"
+  | "declaration", ListV _ -> pp_syntax_decls ~level:0 fmt value
+  | _, ListV [] -> ()
+  | _, ListV values ->
+      values
+      |> List.map (F.asprintf "%a" pp_value)
+      |> String.concat (F.asprintf "%a" pp_sep sep)
+      |> F.fprintf fmt "%s"
+  | _ -> failwith "@pp_list_v: expected ListV value"
 
 and pp_syntax_id fmt (value : value) : unit =
   match flatten_case_v value with
@@ -106,9 +119,9 @@ and pp_syntax_name fmt (value : value) : unit =
   | "nonTypeName", [ [ "TYPE" ] ], [] -> F.fprintf fmt "type"
   | "nonTypeName", [ [ "PRIORITY" ] ], [] -> F.fprintf fmt "priority"
   | "prefixedNonTypeName", [ []; []; [] ], [ dot; non_type_name ] ->
-      F.fprintf fmt "%a%a" pp_case_v dot pp_syntax_name non_type_name
+      F.fprintf fmt "%a%a" pp_case_v dot pp_case_v non_type_name
   | "prefixedType", [ []; []; [] ], [ dot; tid ] ->
-      F.fprintf fmt "%a%a" pp_case_v dot pp_syntax_tid tid
+      F.fprintf fmt "%a%a" pp_case_v dot pp_case_v tid
   | "name", [ [ "LIST" ] ], [] -> F.fprintf fmt "list"
   | _ ->
       failwith
@@ -144,36 +157,37 @@ and pp_syntax_type fmt (value : value) : unit =
   | "baseType", [ [ "VARBIT"; "<" ]; [ ">" ] ], [ value_int ] ->
       F.fprintf fmt "varbit<%a>" pp_value value_int
   | "baseType", [ [ "BIT"; "<"; "(" ]; [ ")"; ">" ] ], [ expr ] ->
-      F.fprintf fmt "bit<(%a)>" pp_syntax_expr expr
+      F.fprintf fmt "bit<(%a)>" pp_value expr
   | "baseType", [ [ "INT"; "<"; "(" ]; [ ")"; ">" ] ], [ expr ] ->
-      F.fprintf fmt "int<(%a)>" pp_syntax_expr expr
+      F.fprintf fmt "int<(%a)>" pp_value expr
   | "baseType", [ [ "VARBIT"; "<"; "(" ]; [ ")"; ">" ] ], [ expr ] ->
-      F.fprintf fmt "varbit<(%a)>" pp_syntax_expr expr
+      F.fprintf fmt "varbit<(%a)>" pp_value expr
   | "baseType", _, _ ->
       failwith
         (F.asprintf "@pp_syntax_type: ill-formed base type:\n%a" pp_case_v value)
   | "specializedType", [ []; [ "<" ]; [ ">" ] ], [ type_name; type_arg_list ] ->
-      F.fprintf fmt "%a<%a>" pp_syntax_name type_name pp_value type_arg_list
+      F.fprintf fmt "%a<%a>" pp_case_v type_name (pp_list_v ~sep:Comma)
+        type_arg_list
   | "specializedType", _, _ ->
       failwith
         (F.asprintf "@pp_syntax_type: ill-formed specialized type:\n%a"
            pp_case_v value)
   | "headerStackType", [ []; [ "[" ]; [ "]" ] ], [ type_name; expr ] ->
-      F.fprintf fmt "%a[%a]" pp_syntax_name type_name pp_syntax_expr expr
+      F.fprintf fmt "%a[%a]" pp_case_v type_name pp_value expr
   | "headerStackType", [ []; [ "[" ]; [ "]"; "PHTM_16" ] ], [ spec_type; expr ]
     ->
-      F.fprintf fmt "%a[%a]" pp_syntax_type spec_type pp_syntax_expr expr
+      F.fprintf fmt "%a[%a]" pp_case_v spec_type pp_value expr
   | "headerStackType", _, _ ->
       failwith
         (F.asprintf "@pp_syntax_type: ill-formed header stack type:\n%a"
            pp_case_v value)
   | "listType", [ [ "LIST"; "<" ]; [ ">" ] ], [ type_arg ] ->
-      F.fprintf fmt "list<%a>" pp_syntax_type_arg type_arg
+      F.fprintf fmt "list<%a>" pp_case_v type_arg
   | "listType", _, _ ->
       failwith
         (F.asprintf "@pp_syntax_type: ill-formed list type:\n%a" pp_case_v value)
   | "tupleType", [ [ "TUPLE"; "<" ]; [ ">" ] ], [ type_arg_list ] ->
-      F.fprintf fmt "tuple<%a>" pp_value type_arg_list
+      F.fprintf fmt "tuple<%a>" (pp_list_v ~sep:Comma) type_arg_list
   | "tupleType", _, _ ->
       failwith
         (F.asprintf "@pp_syntax_type: ill-formed tuple type:\n%a" pp_case_v
@@ -183,6 +197,42 @@ and pp_syntax_type fmt (value : value) : unit =
         (Printf.sprintf "@pp_syntax_type: expected type, got %s"
            (id_of_case_v value))
 
+and pp_syntax_tparams fmt (value : value) : unit =
+  match flatten_case_v value with
+  | "typeParameters", [ [ "<" ]; [ ">" ] ], [ tparams ] ->
+      F.fprintf fmt "<%a>" (pp_list_v ~sep:Comma) tparams
+  | "typeParameters", _, _ ->
+      failwith
+        (F.asprintf "@pp_syntax_tparams: ill-formed type parameters:\n%a"
+           pp_case_v value)
+  | _ ->
+      failwith
+        (Printf.sprintf "@pp_syntax_tparams: expected type parameters, got %s"
+           (id_of_case_v value))
+
+and pp_syntax_params fmt (value : value) : unit =
+  match flatten_case_v value with
+  | ( "parameter",
+      [ []; []; []; []; [] ],
+      [ opt_annotations; dir; type_ref; name ] ) ->
+      F.fprintf fmt "%a%a %a %a" (pp_opt_v ~postfix:" ") opt_annotations
+        pp_case_v dir pp_case_v type_ref pp_case_v name
+  | ( "parameter",
+      [ []; []; []; []; []; [] ],
+      [ opt_annotations; dir; type_ref; name; init ] ) ->
+      F.fprintf fmt "%a%a %a %a%a" (pp_opt_v ~postfix:" ") opt_annotations
+        pp_case_v dir pp_case_v type_ref pp_case_v name pp_case_v init
+  | "parameter", _, _ ->
+      failwith
+        (F.asprintf "@pp_syntax_params: ill-formed parameter:\n%a" pp_case_v
+           value)
+  | "constructorParameters", [ [ "(" ]; [ ")" ] ], [ params ] ->
+      F.fprintf fmt "(%a)" (pp_list_v ~sep:Comma) params
+  | _ ->
+      failwith
+        (Printf.sprintf "@pp_syntax_params: expected parameter, got %s"
+           (id_of_case_v value))
+
 and pp_syntax_expr _fmt (value : value) : unit =
   match flatten_case_v value with
   | _ -> failwith "@pp_syntax_expr: not yet implemented"
@@ -190,6 +240,19 @@ and pp_syntax_expr _fmt (value : value) : unit =
 and pp_syntax_type_arg _fmt (value : value) : unit =
   match flatten_case_v value with
   | _ -> failwith "@pp_syntax_type_arg: not yet implemented"
+
+and pp_syntax_init fmt (value : value) : unit =
+  match flatten_case_v value with
+  | "initializer", [ [ "=" ]; [] ], [ expr ] ->
+      F.fprintf fmt " = %a" pp_syntax_expr expr
+  | "initializer", _, _ ->
+      failwith
+        (F.asprintf "@pp_syntax_init: ill-formed initializer:\n%a" pp_case_v
+           value)
+  | _ ->
+      failwith
+        (Printf.sprintf "@pp_syntax_init: expected initializer, got %s"
+           (id_of_case_v value))
 
 and pp_syntax_stmt _fmt (value : value) : unit =
   match flatten_case_v value with
@@ -225,8 +288,7 @@ and pp_syntax_block fmt (value : value) : unit =
 
 and pp_syntax_decls ~level fmt (value : value) : unit =
   match value.it with
-  | ListV values ->
-      pp_list ~level (pp_syntax_decl ~level) ~sep:SemicolonNl fmt values
+  | ListV values -> pp_list ~level (pp_syntax_decl ~level) ~sep:Nl fmt values
   | _ ->
       failwith
         (F.asprintf "@pp_syntax_decls: expected ListV, got %a" pp_value value)
@@ -296,7 +358,8 @@ and pp_case_v' fmt (value : value) : unit =
       pp_value fmt value_text
   (* Names *)
   | "dotPrefix", [ [ "." ] ], [] -> F.fprintf fmt "."
-  | "direction", [ [ "NONE" ] ], [] -> F.fprintf fmt ""
+  (* Type references *)
+  | "typeOrVoid", [ [ "VOID" ] ], [] -> F.fprintf fmt "void"
   | _ -> pp_default_case_v fmt value
 
 and pp_case_v fmt (value : value) : unit =
@@ -307,8 +370,14 @@ and pp_case_v fmt (value : value) : unit =
   | "headerTypeDeclaration" | "headerUnionDeclaration" | "structTypeDeclaration"
   | "enumDeclaration" | "typeDeclaration" ->
       pp_syntax_decl ~level:0 fmt value
-  | "nonTypeName" | "name" | "prefixedNonTypeName" -> pp_syntax_name fmt value
+  | "nonTypeName" | "name" | "prefixedNonTypeName" | "prefixedType" ->
+      pp_syntax_name fmt value
   | "typeIdentifier" -> pp_syntax_tid fmt value
   | "identifier" -> pp_syntax_id fmt value
   | "direction" -> pp_syntax_dir fmt value
+  | "baseType" | "specializedType" | "headerStackType" | "listType"
+  | "tupleType" ->
+      pp_syntax_type fmt value
+  | "typeParameters" -> pp_syntax_tparams fmt value
+  | "parameter" | "constructorParameters" -> pp_syntax_params fmt value
   | _ -> pp_case_v' fmt value

--- a/p4spec/lib/parsing/pp.ml
+++ b/p4spec/lib/parsing/pp.ml
@@ -83,7 +83,8 @@ and pp_list_v ?(level = 0) ~sep fmt (value : value) : unit =
   match id_of_list_v value with
   | "identifier" | "typeParameterList" | "parameter" | "expression" | "kvPair"
   | "simpleKeysetExpression" | "realTypeArg" | "typeArg" | "argument"
-  | "keyElement" | "action" | "entry" | "annotation" | "simpleAnnotation" ->
+  | "keyElement" | "action" | "entry" | "selectCase" | "annotation"
+  | "simpleAnnotation" ->
       pp_list ~level pp_case_v ~sep fmt values
   | "switchCase" -> pp_list ~level (pp_syntax_stmt' ~level) ~sep fmt values
   | "declOrAssignmentOrMethodCallStatement" ->
@@ -839,6 +840,55 @@ and pp_syntax_ctrl_typ_decl ~level fmt (value : value) : unit =
            "@pp_syntax_ctrl_typ_decl: expected control type declaration, got %s"
            (id_of_case_v value))
 
+and pp_syntax_select_case fmt (value : value) : unit =
+  match flatten_case_v value with
+  | "selectCase", [ []; [ ":" ]; [ ";" ] ], [ keyset_expr; name ] ->
+      F.fprintf fmt "%a: %a;" pp_case_v keyset_expr pp_case_v name
+  | "selectCase", _, _ ->
+      failwith
+        (F.asprintf "@pp_syntax_select_case: ill-formed select case:\n%a"
+           pp_case_v value)
+  | _ ->
+      failwith
+        (Printf.sprintf "@pp_syntax_select_case: expected select case, got %s"
+           (id_of_case_v value))
+
+and pp_syntax_select_expr ~level fmt (value : value) : unit =
+  match flatten_case_v value with
+  | ( "selectExpression",
+      [ [ "SELECT"; "(" ]; [ ")"; "{" ]; [ "}" ] ],
+      [ exprs; cases ] ) ->
+      F.fprintf fmt "select (%a) {\n%a\n%s}"
+        (pp_list_v ~level:0 ~sep:Comma)
+        exprs
+        (pp_list_v ~level:(level + 1) ~sep:Nl)
+        cases (indent level)
+  | "selectExpression", _, _ ->
+      failwith
+        (F.asprintf "@pp_syntax_select_expr: ill-formed select expression:\n%a"
+           pp_case_v value)
+  | _ ->
+      failwith
+        (Printf.sprintf
+           "@pp_syntax_select_expr: expected select expression, got %s"
+           (id_of_case_v value))
+
+and pp_syntax_trans_stmt fmt (value : value) : unit =
+  match flatten_case_v value with
+  | "transitionStatement", [ [ "SPEC_BUG" ] ], [] -> ()
+  | "transitionStatement", [ [ "TRANSITION" ]; [] ], [ state_expr ] ->
+      F.fprintf fmt "transition %a" pp_case_v state_expr
+  | "transitionStatement", _, _ ->
+      failwith
+        (F.asprintf
+           "@pp_syntax_trans_stmt: ill-formed transition statement:\n%a"
+           pp_case_v value)
+  | _ ->
+      failwith
+        (Printf.sprintf
+           "@pp_syntax_trans_stmt: expected transition statement, got %s"
+           (id_of_case_v value))
+
 and pp_syntax_decl ~level fmt (value : value) : unit =
   match flatten_case_v value with
   | ( "constantDeclaration",
@@ -926,6 +976,24 @@ and pp_syntax_decl ~level fmt (value : value) : unit =
         (indent (level + 1))
         (pp_syntax_stmt ~level:(level + 1))
         apply_body (indent level)
+  | ( "valueSetDeclaration",
+      [ []; [ "VALUESET"; "<" ]; [ ">"; "(" ]; [ ")" ]; [ ";" ] ],
+      [ opt_annos; base_type; size; name ] ) ->
+      F.fprintf fmt "%avalueset<%a>(%a) %a"
+        (pp_opt_annos ~level ~sep:Nl)
+        opt_annos pp_case_v base_type pp_case_v size pp_case_v name
+  | ( "valueSetDeclaration",
+      [ []; [ "VALUESET"; "<" ]; [ ">"; "(" ]; [ ")" ]; [ ";"; "PHTM_17" ] ],
+      [ opt_annos; tuple; size; name ] ) ->
+      F.fprintf fmt "%avalueset<%a>(%a) %a"
+        (pp_opt_annos ~level ~sep:Nl)
+        opt_annos pp_case_v tuple pp_case_v size pp_case_v name
+  | ( "valueSetDeclaration",
+      [ []; [ "VALUESET"; "<" ]; [ ">"; "(" ]; [ ")" ]; [ ";"; "PHTM_18" ] ],
+      [ opt_annos; type_name; size; name ] ) ->
+      F.fprintf fmt "%avalueset<%a>(%a) %a"
+        (pp_opt_annos ~level ~sep:Nl)
+        opt_annos pp_case_v type_name pp_case_v size pp_case_v name
   | "parserDeclaration", _, _ -> pp_default_case_v fmt value
   | ( "headerTypeDeclaration",
       [ []; [ "HEADER" ]; []; [ "{" ]; [ "}" ] ],
@@ -982,6 +1050,9 @@ and pp_case_v' fmt (value : value) : unit =
         opt_anno pp_case_v type_ref pp_case_v name
         (pp_opt_v ~postfix:"" pp_case_v)
         opt_init
+  (* Transition statements *)
+  | "stateExpression", [ []; [ ";" ] ], [ name ] ->
+      F.fprintf fmt "%a;" pp_case_v name
   | _ -> pp_default_case_v fmt value
 
 and pp_case_v fmt (value : value) : unit =
@@ -989,8 +1060,9 @@ and pp_case_v fmt (value : value) : unit =
   | "constantDeclaration" | "variableDeclaration" | "errorDeclaration"
   | "matchKindDeclaration" | "externDeclaration" | "instantiation"
   | "functionDeclaration" | "actionDeclaration" | "parserDeclaration"
-  | "controlDeclaration" | "headerTypeDeclaration" | "headerUnionDeclaration"
-  | "structTypeDeclaration" | "enumDeclaration" | "typeDeclaration" ->
+  | "controlDeclaration" | "valueSetDeclaration" | "headerTypeDeclaration"
+  | "headerUnionDeclaration" | "structTypeDeclaration" | "enumDeclaration"
+  | "typeDeclaration" ->
       pp_syntax_decl ~level:0 fmt value
   | "nonTypeName" | "name" | "prefixedNonTypeName" | "prefixedType" ->
       pp_syntax_name fmt value
@@ -1028,4 +1100,6 @@ and pp_case_v fmt (value : value) : unit =
   | "entry" -> pp_syntax_entry fmt value
   | "tableProperty" -> pp_syntax_table_prop ~level:0 fmt value
   | "controlTypeDeclaration" -> pp_syntax_ctrl_typ_decl ~level:0 fmt value
+  | "selectCase" -> pp_syntax_select_case fmt value
+  | "selectExpression" -> pp_syntax_select_expr ~level:0 fmt value
   | _ -> pp_case_v' fmt value

--- a/p4spec/lib/parsing/pp.ml
+++ b/p4spec/lib/parsing/pp.ml
@@ -9,6 +9,18 @@ module F = Format
 
 let verbose = ref false
 
+(**** SpecTec IL ****)
+
+(* Numbers *)
+
+let pp_num fmt (num : num) : unit =
+  match num with
+  | `Nat n -> F.fprintf fmt "%s" (Bigint.to_string n)
+  | `Int i ->
+      F.fprintf fmt "%s"
+        ((if i >= Bigint.zero then "" else "-")
+        ^ Bigint.to_string (Bigint.abs i))
+
 (* Atoms *)
 
 let pp_atom fmt (atom : atom) : unit =
@@ -25,19 +37,9 @@ let pp_atoms fmt (atoms : atom list) : unit =
       in
       F.fprintf fmt "%s" (String.concat "" atoms)
 
-(* Numbers *)
+(* Values *)
 
-let rec pp_num fmt (num : num) : unit =
-  match num with
-  | `Nat n -> F.fprintf fmt "%s" (Bigint.to_string n)
-  | `Int i ->
-      F.fprintf fmt "%s"
-        ((if i >= Bigint.zero then "" else "-")
-        ^ Bigint.to_string (Bigint.abs i))
-
-(* IL Values *)
-
-and pp_value fmt (value : value) : unit =
+let rec pp_value fmt (value : value) : unit =
   match value.it with
   | BoolV b -> F.fprintf fmt "%b" b
   | NumV n -> F.fprintf fmt "%a" pp_num n
@@ -59,6 +61,88 @@ and pp_text_v ~escaped fmt (value : value) : unit =
   | TextV text ->
       if escaped then F.fprintf fmt "%S" text else F.fprintf fmt "%s" text
   | _ -> failwith "@pp_text_v: expected TextV value"
+
+(* CaseV *)
+
+and pp_case_v fmt (value : value) : unit =
+  match id_of_case_v value with
+  | "constantDeclaration" | "variableDeclarationWithoutSemicolon"
+  | "variableDeclaration" | "errorDeclaration" | "matchKindDeclaration"
+  | "externDeclaration" | "instantiation" | "functionDeclaration"
+  | "actionDeclaration" | "parserDeclaration" | "controlTypeDeclaration"
+  | "controlDeclaration" | "valueSetDeclaration" | "headerTypeDeclaration"
+  | "headerUnionDeclaration" | "structTypeDeclaration" | "parserTypeDeclaration"
+  | "enumDeclaration" | "typedefDeclaration" | "typeDeclaration"
+  | "packageTypeDeclaration" ->
+      pp_syntax_decl ~level:0 fmt value
+  | "trailingComma" -> pp_syntax_comma fmt value
+  | "const" -> pp_syntax_const fmt value
+  | "number" -> pp_syntax_num fmt value
+  | "stringLiteral" -> pp_syntax_str fmt value
+  | "dotPrefix" | "nonTypeName" | "name" | "prefixedNonTypeName"
+  | "prefixedType" ->
+      pp_syntax_name fmt value
+  | "typeIdentifier" -> pp_syntax_tid fmt value
+  | "identifier" -> pp_syntax_id fmt value
+  | "direction" -> pp_syntax_dir fmt value
+  | "baseType" | "specializedType" | "headerStackType" | "listType"
+  | "tupleType" | "typeOrVoid" ->
+      pp_syntax_type fmt value
+  | "typeParameters" -> pp_syntax_tparams fmt value
+  | "parameter" | "constructorParameters" -> pp_syntax_params fmt value
+  | "nonBraceExpression" -> pp_syntax_nb_expr fmt value
+  | "expression" -> pp_syntax_expr fmt value
+  | "simpleKeysetExpression" | "reducedSimpleKeysetExpression"
+  | "tupleKeysetExpression" ->
+      pp_syntax_keyset_expr fmt value
+  | "kvPair" -> pp_syntax_kvpair fmt value
+  | "realTypeArg" | "typeArg" -> pp_syntax_targ fmt value
+  | "argument" -> pp_syntax_arg fmt value
+  | "lvalue" -> pp_syntax_lvalue fmt value
+  | "initializer" -> pp_syntax_init fmt value
+  | "assignmentOrMethodCallStatementWithoutSemicolon" | "switchLabel"
+  | "switchCase" | "forCollectionExpr"
+  | "assignmentOrMethodCallStatement" | "directApplication"
+  | "conditionalStatement" | "emptyStatement" | "blockStatement"
+  | "returnStatement" | "breakStatement" | "continueStatement" | "exitStatement"
+  | "switchStatement" | "forStatement" ->
+      pp_syntax_stmt ~level:0 fmt value
+  | "functionPrototype" -> pp_syntax_func fmt value
+  | "methodPrototype" -> pp_syntax_mthd ~level:0 fmt value
+  | "keyElement" -> pp_syntax_key fmt value
+  | "actionRef" -> pp_syntax_action_ref fmt value
+  | "action" -> pp_syntax_action ~level:0 fmt value
+  | "entryPriority" -> pp_syntax_entry_prio fmt value
+  | "entry" -> pp_syntax_entry fmt value
+  | "tableProperty" -> pp_syntax_table_prop ~level:0 fmt value
+  | "selectCase" -> pp_syntax_select_case fmt value
+  | "selectExpression" -> pp_syntax_select_expr ~level:0 fmt value
+  | "stateExpression" -> pp_syntax_state_expr ~level:0 fmt value
+  | "transitionStatement" -> pp_syntax_trans_stmt ~level:0 fmt value
+  | "parserBlockStatement" -> pp_syntax_parser_stmt ~level:0 fmt value
+  | "parserState" -> pp_syntax_parser_state ~level:0 fmt value
+  | "specifiedIdentifier" -> pp_syntax_spec_id fmt value
+  | "structField" -> pp_syntax_struct_field fmt value
+  | "annotationToken" -> pp_syntax_anno_token fmt value
+  | "simpleAnnotation" | "structuredAnnotationBody" ->
+      pp_syntax_anno_body fmt value
+  | "annotation" -> pp_syntax_anno fmt value
+  | _ -> pp_default_case_v fmt value
+
+and pp_default_case_v fmt value : unit =
+  match value.it with
+  | CaseV (mixop, values) ->
+      let len = List.length mixop + List.length values in
+      List.init len (fun idx ->
+          if idx mod 2 = 0 then
+            idx / 2 |> List.nth mixop |> F.asprintf "%a" pp_atoms
+          else idx / 2 |> List.nth values |> F.asprintf "%a" pp_value)
+      |> List.filter (fun str -> str <> "")
+      |> String.concat " "
+      |>
+      if !verbose then F.fprintf fmt "@%s_< %s>_@" (id_of_case_v value)
+      else F.fprintf fmt "%s"
+  | _ -> failwith "@pp_default_case_v: Expected CaseV value"
 
 (* OptV *)
 
@@ -84,11 +168,11 @@ and pp_list_v ?(level = 0) ~sep fmt (value : value) : unit =
   | "keyElement" | "entry" | "selectCase" | "specifiedIdentifier"
   | "structField" | "simpleAnnotation" ->
       pp_list ~level pp_case_v ~sep fmt values
-  | "switchCase" -> pp_list ~level (pp_syntax_stmt' ~level) ~sep fmt values
+  | "switchCase" -> pp_list ~level (pp_syntax_stmt ~level) ~sep fmt values
   | "declOrAssignmentOrMethodCallStatement" ->
       pp_list pp_syntax_decl_or_assign_or_call_stmt ~sep fmt values
   | "assignmentOrMethodCallStatement" ->
-      pp_list (pp_syntax_stmt' ~level:0) ~sep fmt values
+      pp_list (pp_syntax_stmt ~level:0) ~sep fmt values
   | "statementOrDeclaration" ->
       pp_list ~level (pp_syntax_stat_or_decl ~level) ~sep fmt values
   | "methodPrototype" -> pp_list ~level (pp_syntax_mthd ~level) ~sep fmt values
@@ -109,22 +193,9 @@ and pp_list_v ?(level = 0) ~sep fmt (value : value) : unit =
       failwith
         (Printf.sprintf "@pp_list_v: unknown ListV: %s" (id_of_list_v value))
 
-(* Default CaseV *)
+(**** P4 Syntax ****)
 
-and pp_default_case_v fmt value : unit =
-  match value.it with
-  | CaseV (mixop, values) ->
-      let len = List.length mixop + List.length values in
-      List.init len (fun idx ->
-          if idx mod 2 = 0 then
-            idx / 2 |> List.nth mixop |> F.asprintf "%a" pp_atoms
-          else idx / 2 |> List.nth values |> F.asprintf "%a" pp_value)
-      |> List.filter (fun str -> str <> "")
-      |> String.concat " "
-      |>
-      if !verbose then F.fprintf fmt "@%s_< %s>_@" (id_of_case_v value)
-      else F.fprintf fmt "%s"
-  | _ -> failwith "@pp_default_case_v: Expected CaseV value"
+(** Misc **)
 
 (* Trailing commas *)
 
@@ -154,7 +225,7 @@ and pp_syntax_const fmt (value : value) : unit =
         (Printf.sprintf "@pp_syntax_const: expected const, got %s"
            (id_of_case_v value))
 
-(* Numbers *)
+(** Numbers **)
 
 and pp_syntax_num fmt (value : value) : unit =
   match flatten_case_v value with
@@ -173,7 +244,7 @@ and pp_syntax_num fmt (value : value) : unit =
         (Printf.sprintf "@pp_syntax_num: expected number, got %s"
            (id_of_case_v value))
 
-(* Strings *)
+(** Strings **)
 
 and pp_syntax_str fmt (value : value) : unit =
   match flatten_case_v value with
@@ -187,6 +258,8 @@ and pp_syntax_str fmt (value : value) : unit =
       failwith
         (Printf.sprintf "@pp_syntax_str: expected string, got %s"
            (id_of_case_v value))
+
+(** Names **)
 
 (* Identifiers *)
 
@@ -218,8 +291,6 @@ and pp_syntax_tid fmt (value : value) : unit =
         (Printf.sprintf "@pp_syntax_tid: expected typeIdentifier, got %s"
            (id_of_case_v value))
 
-(* Names *)
-
 and pp_syntax_name fmt (value : value) : unit =
   match flatten_case_v value with
   | "dotPrefix", [ [ "." ] ], [] -> F.fprintf fmt "."
@@ -240,7 +311,7 @@ and pp_syntax_name fmt (value : value) : unit =
         (Printf.sprintf "@pp_syntax_name: expected name, got %s"
            (id_of_case_v value))
 
-(* Directions *)
+(** Directions **)
 
 and pp_syntax_dir fmt (value : value) : unit =
   match flatten_case_v value with
@@ -256,10 +327,11 @@ and pp_syntax_dir fmt (value : value) : unit =
         (Printf.sprintf "@pp_syntax_dir: expected direction, got %s"
            (id_of_case_v value))
 
-(* Types *)
+(** Types **)
 
 and pp_syntax_type fmt (value : value) : unit =
   match flatten_case_v value with
+  (* Base types *)
   | "baseType", [ [ "BOOL" ] ], [] -> F.fprintf fmt "bool"
   | "baseType", [ [ "MATCH_KIND" ] ], [] -> F.fprintf fmt "match_kind"
   | "baseType", [ [ "ERROR" ] ], [] -> F.fprintf fmt "error"
@@ -281,6 +353,7 @@ and pp_syntax_type fmt (value : value) : unit =
   | "baseType", _, _ ->
       failwith
         (F.asprintf "@pp_syntax_type: ill-formed base type:\n%a" pp_case_v value)
+  (* Named types *)
   | "specializedType", [ []; [ "<" ]; [ ">" ] ], [ type_name; type_arg_list ] ->
       F.fprintf fmt "%a<%a>" pp_case_v type_name
         (pp_list_v ~level:0 ~sep:Comma)
@@ -289,6 +362,7 @@ and pp_syntax_type fmt (value : value) : unit =
       failwith
         (F.asprintf "@pp_syntax_type: ill-formed specialized type:\n%a"
            pp_case_v value)
+  (* Header stack types *)
   | "headerStackType", [ []; [ "[" ]; [ "]" ] ], [ type_name; expr ] ->
       F.fprintf fmt "%a[%a]" pp_case_v type_name pp_value expr
   | "headerStackType", [ []; [ "[" ]; [ "]"; "PHTM_16" ] ], [ spec_type; expr ]
@@ -298,24 +372,27 @@ and pp_syntax_type fmt (value : value) : unit =
       failwith
         (F.asprintf "@pp_syntax_type: ill-formed header stack type:\n%a"
            pp_case_v value)
+  (* List types *)
   | "listType", [ [ "LIST"; "<" ]; [ ">" ] ], [ type_arg ] ->
       F.fprintf fmt "list<%a>" pp_case_v type_arg
   | "listType", _, _ ->
       failwith
         (F.asprintf "@pp_syntax_type: ill-formed list type:\n%a" pp_case_v value)
+  (* Tuple types *)
   | "tupleType", [ [ "TUPLE"; "<" ]; [ ">" ] ], [ type_arg_list ] ->
       F.fprintf fmt "tuple<%a>" (pp_list_v ~level:0 ~sep:Comma) type_arg_list
   | "tupleType", _, _ ->
       failwith
         (F.asprintf "@pp_syntax_type: ill-formed tuple type:\n%a" pp_case_v
            value)
+  (* Type references *)
   | "typeOrVoid", [ [ "VOID" ] ], [] -> F.fprintf fmt "void"
   | _ ->
       failwith
         (Printf.sprintf "@pp_syntax_type: expected type, got %s"
            (id_of_case_v value))
 
-(* Type parameters *)
+(** Type parameters **)
 
 and pp_syntax_tparams fmt (value : value) : unit =
   match flatten_case_v value with
@@ -330,7 +407,7 @@ and pp_syntax_tparams fmt (value : value) : unit =
         (Printf.sprintf "@pp_syntax_tparams: expected type parameters, got %s"
            (id_of_case_v value))
 
-(* Parameters *)
+(** Parameters **)
 
 and pp_syntax_params fmt (value : value) : unit =
   match flatten_case_v value with
@@ -348,6 +425,7 @@ and pp_syntax_params fmt (value : value) : unit =
       failwith
         (F.asprintf "@pp_syntax_params: ill-formed parameter:\n%a" pp_case_v
            value)
+  (** Constructor parameters **)
   | "constructorParameters", [ [ "(" ]; [ ")" ] ], [ params ] ->
       F.fprintf fmt "(%a)" (pp_list_v ~level:0 ~sep:Comma) params
   | _ ->
@@ -355,7 +433,7 @@ and pp_syntax_params fmt (value : value) : unit =
         (Printf.sprintf "@pp_syntax_params: expected parameter, got %s"
            (id_of_case_v value))
 
-(* Non-brace expressions *)
+(** Expressions **)
 
 and pp_syntax_nb_expr fmt (value : value) : unit =
   let is_binary_op = function
@@ -417,8 +495,6 @@ and pp_syntax_nb_expr fmt (value : value) : unit =
         (Printf.sprintf
            "@pp_syntax_nb_expr: expected non-brace expression, got %s"
            (id_of_case_v value))
-
-(* Expressions *)
 
 and pp_syntax_expr fmt (value : value) : unit =
   let is_binary_op = function
@@ -501,7 +577,7 @@ and pp_syntax_expr fmt (value : value) : unit =
         (Printf.sprintf "@pp_syntax_expr: expected expression, got %s"
            (id_of_case_v value))
 
-(* Keyset expressions *)
+(** Keyset expressions **)
 
 and pp_syntax_keyset_expr fmt (value : value) : unit =
   match flatten_case_v value with
@@ -546,7 +622,7 @@ and pp_syntax_keyset_expr fmt (value : value) : unit =
            "@pp_syntax_keyset_expr: expected keyset expression, got %s"
            (id_of_case_v value))
 
-(* Key value pairs *)
+(** Expression key-value pairs **)
 
 and pp_syntax_kvpair fmt (value : value) : unit =
   match flatten_case_v value with
@@ -561,7 +637,7 @@ and pp_syntax_kvpair fmt (value : value) : unit =
         (Printf.sprintf "@pp_syntax_kvpair: expected key value pair, got %s"
            (id_of_case_v value))
 
-(* Type arguments *)
+(** Type arguments **)
 
 and pp_syntax_targ fmt (value : value) : unit =
   match flatten_case_v value with
@@ -582,7 +658,7 @@ and pp_syntax_targ fmt (value : value) : unit =
         (Printf.sprintf "@pp_syntax_targ: expected type argument, got %s"
            (id_of_case_v value))
 
-(* Arguments *)
+(** Arguments **)
 
 and pp_syntax_arg fmt (value : value) : unit =
   match flatten_case_v value with
@@ -599,7 +675,7 @@ and pp_syntax_arg fmt (value : value) : unit =
         (Printf.sprintf "@pp_syntax_arg: expected argument, got %s"
            (id_of_case_v value))
 
-(* L-values *)
+(** L-values **)
 
 and pp_syntax_lvalue fmt (value : value) : unit =
   match flatten_case_v value with
@@ -620,6 +696,8 @@ and pp_syntax_lvalue fmt (value : value) : unit =
         (Printf.sprintf "@pp_syntax_lvalue: expected l-value, got %s"
            (id_of_case_v value))
 
+(** Statements and declarations **)
+
 (* Initializers *)
 
 and pp_syntax_init fmt (value : value) : unit =
@@ -637,48 +715,13 @@ and pp_syntax_init fmt (value : value) : unit =
 
 (* Statements *)
 
-and pp_syntax_stmt' ~level fmt (value : value) : unit =
+and pp_syntax_stmt ~level fmt (value : value) : unit =
   let is_assign_op = function
     | "=" | "+=" | "|+|=" | "-=" | "|-|=" | "*=" | "/=" | "%=" | "<<=" | ">>="
     | "&=" | "^=" | "|=" ->
         true
     | _ -> false
   in
-  match flatten_case_v value with
-  | ( "assignmentOrMethodCallStatementWithoutSemicolon",
-      [ []; [ "(" ]; [ ")" ] ],
-      [ func; args ] ) ->
-      F.fprintf fmt "%a(%a)" pp_case_v func (pp_list_v ~level:0 ~sep:Comma) args
-  | ( "assignmentOrMethodCallStatementWithoutSemicolon",
-      [ []; [ "<" ]; [ ">"; "(" ]; [ ")" ] ],
-      [ func; targs; args ] ) ->
-      F.fprintf fmt "%a<%a>(%a)" pp_case_v func
-        (pp_list_v ~level:0 ~sep:Comma)
-        targs
-        (pp_list_v ~level:0 ~sep:Comma)
-        args
-  | ( "assignmentOrMethodCallStatementWithoutSemicolon",
-      [ []; [ assign_op ]; [] ],
-      [ lhs; rhs ] )
-    when is_assign_op assign_op ->
-      F.fprintf fmt "%a %s (%a)" pp_case_v lhs assign_op pp_case_v rhs
-  | "assignmentOrMethodCallStatementWithoutSemicolon", _, _ ->
-      failwith
-        (F.asprintf "@pp_syntax_stmt': ill-formed statement helper:\n%a"
-           pp_case_v value)
-  | "switchLabel", [ [ "DEFAULT" ] ], [] -> F.fprintf fmt "default"
-  | "switchCase", [ []; [ ":" ]; [] ], [ label; code ] ->
-      F.fprintf fmt "%a: %a" pp_case_v label (pp_syntax_stmt ~level) code
-  | "switchCase", [ []; [ ":" ] ], [ label ] ->
-      F.fprintf fmt "%a:" pp_case_v label
-  | "forCollectionExpr", [ []; [ ".." ]; [] ], [ expr_l; expr_r ] ->
-      F.fprintf fmt "(%a)..(%a)" pp_case_v expr_l pp_case_v expr_r
-  | _ ->
-      failwith
-        (Printf.sprintf "@pp_syntax_stmt': expected statement helper, got %s"
-           (id_of_case_v value))
-
-and pp_syntax_stmt ~level fmt (value : value) : unit =
   match flatten_case_v value with
   | "assignmentOrMethodCallStatement", [ []; [ ";" ] ], [ stmt' ] ->
       F.fprintf fmt "%a;" pp_case_v stmt'
@@ -741,6 +784,34 @@ and pp_syntax_stmt ~level fmt (value : value) : unit =
         (pp_opt_annos ~level:0 ~sep:Space)
         opt_annos_in pp_case_v typ pp_case_v name pp_case_v collection
         (pp_syntax_stmt ~level) body
+  | ( "assignmentOrMethodCallStatementWithoutSemicolon",
+      [ []; [ "(" ]; [ ")" ] ],
+      [ func; args ] ) ->
+      F.fprintf fmt "%a(%a)" pp_case_v func (pp_list_v ~level:0 ~sep:Comma) args
+  | ( "assignmentOrMethodCallStatementWithoutSemicolon",
+      [ []; [ "<" ]; [ ">"; "(" ]; [ ")" ] ],
+      [ func; targs; args ] ) ->
+      F.fprintf fmt "%a<%a>(%a)" pp_case_v func
+        (pp_list_v ~level:0 ~sep:Comma)
+        targs
+        (pp_list_v ~level:0 ~sep:Comma)
+        args
+  | ( "assignmentOrMethodCallStatementWithoutSemicolon",
+      [ []; [ assign_op ]; [] ],
+      [ lhs; rhs ] )
+    when is_assign_op assign_op ->
+      F.fprintf fmt "%a %s (%a)" pp_case_v lhs assign_op pp_case_v rhs
+  | "assignmentOrMethodCallStatementWithoutSemicolon", _, _ ->
+      failwith
+        (F.asprintf "@pp_syntax_stmt: ill-formed statement helper:\n%a"
+           pp_case_v value)
+  | "switchLabel", [ [ "DEFAULT" ] ], [] -> F.fprintf fmt "default"
+  | "switchCase", [ []; [ ":" ]; [] ], [ label; code ] ->
+      F.fprintf fmt "%a: %a" pp_case_v label (pp_syntax_stmt ~level) code
+  | "switchCase", [ []; [ ":" ] ], [ label ] ->
+      F.fprintf fmt "%a:" pp_case_v label
+  | "forCollectionExpr", [ []; [ ".." ]; [] ], [ expr_l; expr_r ] ->
+      F.fprintf fmt "(%a)..(%a)" pp_case_v expr_l pp_case_v expr_r
   | _ ->
       failwith
         (Printf.sprintf "@pp_syntax_stmt: expected statement, got %s"
@@ -820,7 +891,7 @@ and pp_syntax_decl_or_assign_or_call_stmt fmt (value : value) : unit =
   match id_of_case_v value with
   | "variableDeclarationWithoutSemicolon" -> pp_case_v fmt value
   | "assignmentOrMethodCallStatementWithoutSemicolon" ->
-      pp_syntax_stmt' ~level:0 fmt value
+      pp_syntax_stmt ~level:0 fmt value
   | _ ->
       failwith
         (Printf.sprintf
@@ -1525,70 +1596,3 @@ and pp_opt_annos ?(level = 0) ~(sep : sep) fmt (value : value) : unit =
   let postfix = if is_nl sep then F.sprintf "\n%s" (indent level) else " " in
   pp_opt_v ~postfix (pp_list_v ~level ~sep) fmt value
 
-(* CaseV *)
-
-and pp_case_v fmt (value : value) : unit =
-  match id_of_case_v value with
-  | "constantDeclaration" | "variableDeclarationWithoutSemicolon"
-  | "variableDeclaration" | "errorDeclaration" | "matchKindDeclaration"
-  | "externDeclaration" | "instantiation" | "functionDeclaration"
-  | "actionDeclaration" | "parserDeclaration" | "controlTypeDeclaration"
-  | "controlDeclaration" | "valueSetDeclaration" | "headerTypeDeclaration"
-  | "headerUnionDeclaration" | "structTypeDeclaration" | "parserTypeDeclaration"
-  | "enumDeclaration" | "typedefDeclaration" | "typeDeclaration"
-  | "packageTypeDeclaration" ->
-      pp_syntax_decl ~level:0 fmt value
-  | "trailingComma" -> pp_syntax_comma fmt value
-  | "const" -> pp_syntax_const fmt value
-  | "number" -> pp_syntax_num fmt value
-  | "stringLiteral" -> pp_syntax_str fmt value
-  | "dotPrefix" | "nonTypeName" | "name" | "prefixedNonTypeName"
-  | "prefixedType" ->
-      pp_syntax_name fmt value
-  | "typeIdentifier" -> pp_syntax_tid fmt value
-  | "identifier" -> pp_syntax_id fmt value
-  | "direction" -> pp_syntax_dir fmt value
-  | "baseType" | "specializedType" | "headerStackType" | "listType"
-  | "tupleType" | "typeOrVoid" ->
-      pp_syntax_type fmt value
-  | "typeParameters" -> pp_syntax_tparams fmt value
-  | "parameter" | "constructorParameters" -> pp_syntax_params fmt value
-  | "nonBraceExpression" -> pp_syntax_nb_expr fmt value
-  | "expression" -> pp_syntax_expr fmt value
-  | "simpleKeysetExpression" | "reducedSimpleKeysetExpression"
-  | "tupleKeysetExpression" ->
-      pp_syntax_keyset_expr fmt value
-  | "kvPair" -> pp_syntax_kvpair fmt value
-  | "realTypeArg" | "typeArg" -> pp_syntax_targ fmt value
-  | "argument" -> pp_syntax_arg fmt value
-  | "lvalue" -> pp_syntax_lvalue fmt value
-  | "initializer" -> pp_syntax_init fmt value
-  | "assignmentOrMethodCallStatementWithoutSemicolon" | "switchLabel"
-  | "switchCase" | "forCollectionExpr" ->
-      pp_syntax_stmt' ~level:0 fmt value
-  | "assignmentOrMethodCallStatement" | "directApplication"
-  | "conditionalStatement" | "emptyStatement" | "blockStatement"
-  | "returnStatement" | "breakStatement" | "continueStatement" | "exitStatement"
-  | "switchStatement" | "forStatement" ->
-      pp_syntax_stmt ~level:0 fmt value
-  | "functionPrototype" -> pp_syntax_func fmt value
-  | "methodPrototype" -> pp_syntax_mthd ~level:0 fmt value
-  | "keyElement" -> pp_syntax_key fmt value
-  | "actionRef" -> pp_syntax_action_ref fmt value
-  | "action" -> pp_syntax_action ~level:0 fmt value
-  | "entryPriority" -> pp_syntax_entry_prio fmt value
-  | "entry" -> pp_syntax_entry fmt value
-  | "tableProperty" -> pp_syntax_table_prop ~level:0 fmt value
-  | "selectCase" -> pp_syntax_select_case fmt value
-  | "selectExpression" -> pp_syntax_select_expr ~level:0 fmt value
-  | "stateExpression" -> pp_syntax_state_expr ~level:0 fmt value
-  | "transitionStatement" -> pp_syntax_trans_stmt ~level:0 fmt value
-  | "parserBlockStatement" -> pp_syntax_parser_stmt ~level:0 fmt value
-  | "parserState" -> pp_syntax_parser_state ~level:0 fmt value
-  | "specifiedIdentifier" -> pp_syntax_spec_id fmt value
-  | "structField" -> pp_syntax_struct_field fmt value
-  | "annotationToken" -> pp_syntax_anno_token fmt value
-  | "simpleAnnotation" | "structuredAnnotationBody" ->
-      pp_syntax_anno_body fmt value
-  | "annotation" -> pp_syntax_anno fmt value
-  | _ -> pp_default_case_v fmt value

--- a/p4spec/lib/parsing/pp.ml
+++ b/p4spec/lib/parsing/pp.ml
@@ -72,17 +72,31 @@ and pp_opt_v ?(postfix = "") fmt (value : value) : unit =
   | OptV None -> F.fprintf fmt ""
   | _ -> failwith "@pp_opt_v: expected OptV value"
 
-and pp_list_v ?(sep = Comma) fmt (value : value) : unit =
-  match (id_of_list_v value, value.it) with
-  | "declaration", ListV [] -> F.fprintf fmt ";"
-  | "declaration", ListV _ -> pp_syntax_decls ~level:0 fmt value
-  | _, ListV [] -> ()
-  | _, ListV values ->
-      values
-      |> List.map (F.asprintf "%a" pp_value)
-      |> String.concat (F.asprintf "%a" pp_sep sep)
-      |> F.fprintf fmt "%s"
-  | _ -> failwith "@pp_list_v: expected ListV value"
+and pp_list_v ?(level = 0) fmt (value : value) : unit =
+  let values =
+    match value.it with
+    | ListV values -> values
+    | _ ->
+        failwith
+          (F.asprintf "@pp_list_v: expected ListV, got %a" pp_value value)
+  in
+  match id_of_list_v value with
+  | "identifier" | "typeParameterList" | "parameter" | "expression" | "kvPair"
+  | "simpleKeysetExpression" | "realTypeArg" | "typeArg" | "argument" ->
+      pp_list pp_case_v ~sep:Comma fmt values
+  | "switchCase" -> pp_list ~level (pp_syntax_stmt' ~level) ~sep:Nl fmt values
+  | "declOrAssignmentOrMethodCallStatement" ->
+      pp_list pp_syntax_decl_or_assign_or_call_stmt ~sep:Comma fmt values
+  | "assignmentOrMethodCallStatement" ->
+      pp_list (pp_syntax_stmt' ~level:0) ~sep:Comma fmt values
+  | "statementOrDeclaration" ->
+      pp_list ~level (pp_syntax_stat_or_decl ~level) ~sep:Nl fmt values
+  | "declaration" when List.compare_length_with values 0 = 0 ->
+      F.fprintf fmt ";"
+  | "declaration" -> pp_list ~level (pp_syntax_decl ~level) ~sep:Nl fmt values
+  | _ ->
+      failwith
+        (Printf.sprintf "@pp_list_v: unknown ListV: %s" (id_of_list_v value))
 
 and pp_syntax_id fmt (value : value) : unit =
   match flatten_case_v value with
@@ -166,7 +180,7 @@ and pp_syntax_type fmt (value : value) : unit =
       failwith
         (F.asprintf "@pp_syntax_type: ill-formed base type:\n%a" pp_case_v value)
   | "specializedType", [ []; [ "<" ]; [ ">" ] ], [ type_name; type_arg_list ] ->
-      F.fprintf fmt "%a<%a>" pp_case_v type_name (pp_list_v ~sep:Comma)
+      F.fprintf fmt "%a<%a>" pp_case_v type_name (pp_list_v ~level:0)
         type_arg_list
   | "specializedType", _, _ ->
       failwith
@@ -187,7 +201,7 @@ and pp_syntax_type fmt (value : value) : unit =
       failwith
         (F.asprintf "@pp_syntax_type: ill-formed list type:\n%a" pp_case_v value)
   | "tupleType", [ [ "TUPLE"; "<" ]; [ ">" ] ], [ type_arg_list ] ->
-      F.fprintf fmt "tuple<%a>" (pp_list_v ~sep:Comma) type_arg_list
+      F.fprintf fmt "tuple<%a>" (pp_list_v ~level:0) type_arg_list
   | "tupleType", _, _ ->
       failwith
         (F.asprintf "@pp_syntax_type: ill-formed tuple type:\n%a" pp_case_v
@@ -200,7 +214,7 @@ and pp_syntax_type fmt (value : value) : unit =
 and pp_syntax_tparams fmt (value : value) : unit =
   match flatten_case_v value with
   | "typeParameters", [ [ "<" ]; [ ">" ] ], [ tparams ] ->
-      F.fprintf fmt "<%a>" (pp_list_v ~sep:Comma) tparams
+      F.fprintf fmt "<%a>" (pp_list_v ~level:0) tparams
   | "typeParameters", _, _ ->
       failwith
         (F.asprintf "@pp_syntax_tparams: ill-formed type parameters:\n%a"
@@ -212,22 +226,20 @@ and pp_syntax_tparams fmt (value : value) : unit =
 
 and pp_syntax_params fmt (value : value) : unit =
   match flatten_case_v value with
-  | ( "parameter",
-      [ []; []; []; []; [] ],
-      [ opt_annotations; dir; type_ref; name ] ) ->
-      F.fprintf fmt "%a%a %a %a" (pp_opt_v ~postfix:" ") opt_annotations
-        pp_case_v dir pp_case_v type_ref pp_case_v name
+  | "parameter", [ []; []; []; []; [] ], [ opt_annos; dir; type_ref; name ] ->
+      F.fprintf fmt "%a%a %a %a" (pp_opt_v ~postfix:" ") opt_annos pp_case_v dir
+        pp_case_v type_ref pp_case_v name
   | ( "parameter",
       [ []; []; []; []; []; [] ],
-      [ opt_annotations; dir; type_ref; name; init ] ) ->
-      F.fprintf fmt "%a%a %a %a%a" (pp_opt_v ~postfix:" ") opt_annotations
-        pp_case_v dir pp_case_v type_ref pp_case_v name pp_case_v init
+      [ opt_annos; dir; type_ref; name; init ] ) ->
+      F.fprintf fmt "%a%a %a %a%a" (pp_opt_v ~postfix:" ") opt_annos pp_case_v
+        dir pp_case_v type_ref pp_case_v name pp_case_v init
   | "parameter", _, _ ->
       failwith
         (F.asprintf "@pp_syntax_params: ill-formed parameter:\n%a" pp_case_v
            value)
   | "constructorParameters", [ [ "(" ]; [ ")" ] ], [ params ] ->
-      F.fprintf fmt "(%a)" (pp_list_v ~sep:Comma) params
+      F.fprintf fmt "(%a)" (pp_list_v ~level:0) params
   | _ ->
       failwith
         (Printf.sprintf "@pp_syntax_params: expected parameter, got %s"
@@ -273,12 +285,12 @@ and pp_syntax_nb_expr fmt (value : value) : unit =
   | ( "nonBraceExpression",
       [ []; [ "<" ]; [ ">"; "(" ]; [ ")" ] ],
       [ func; type_args; args ] ) ->
-      F.fprintf fmt "(%a)<%a>(%a)" pp_case_v func (pp_list_v ~sep:Comma)
-        type_args (pp_list_v ~sep:Comma) args
+      F.fprintf fmt "(%a)<%a>(%a)" pp_case_v func (pp_list_v ~level:0) type_args
+        (pp_list_v ~level:0) args
   | "nonBraceExpression", [ []; [ "(" ]; [ ")" ] ], [ func; args ] ->
-      F.fprintf fmt "(%a)(%a)" pp_case_v func (pp_list_v ~sep:Comma) args
+      F.fprintf fmt "(%a)(%a)" pp_case_v func (pp_list_v ~level:0) args
   | "nonBraceExpression", [ []; [ "(" ]; [ ")"; "PHTM_6" ] ], [ typ; args ] ->
-      F.fprintf fmt "(%a)(%a)" pp_case_v typ (pp_list_v ~sep:Comma) args
+      F.fprintf fmt "(%a)(%a)" pp_case_v typ (pp_list_v ~level:0) args
   | "nonBraceExpression", [ [ "(" ]; [ ")" ]; [] ], [ typ; expr ] ->
       F.fprintf fmt "(%a)(%a)" pp_case_v typ pp_case_v expr
   | "nonBraceExpression", _, _ ->
@@ -310,14 +322,14 @@ and pp_syntax_expr fmt (value : value) : unit =
   | "expression", [ []; [ "[" ]; [ ":" ]; [ "]" ] ], [ bits; hi; lo ] ->
       F.fprintf fmt "(%a)[%a:%a]" pp_case_v bits pp_case_v hi pp_case_v lo
   | "expression", [ [ "{" ]; []; [ "}" ] ], [ exprs; comma ] ->
-      F.fprintf fmt "{ %a%a }" (pp_list_v ~sep:Comma) exprs
-        (pp_opt_v ~postfix:"") comma
+      F.fprintf fmt "{ %a%a }" (pp_list_v ~level:0) exprs (pp_opt_v ~postfix:"")
+        comma
   | "expression", [ [ "INVALID" ] ], [] -> F.fprintf fmt "{#}"
   | "expression", [ [ "{" ]; []; [ "}"; "PHTM_7" ] ], [ kvs; comma ] ->
-      F.fprintf fmt "{ %a%a }" (pp_list_v ~sep:Comma) kvs (pp_opt_v ~postfix:"")
+      F.fprintf fmt "{ %a%a }" (pp_list_v ~level:0) kvs (pp_opt_v ~postfix:"")
         comma
   | "expression", [ [ "{" ]; [ ","; "..." ]; [ "}" ] ], [ kvs; comma ] ->
-      F.fprintf fmt "{ %a, ...%a }" (pp_list_v ~sep:Comma) kvs
+      F.fprintf fmt "{ %a, ...%a }" (pp_list_v ~level:0) kvs
         (pp_opt_v ~postfix:"") comma
   | "expression", [ [ "!" ]; [] ], [ arg ] ->
       F.fprintf fmt "!(%a)" pp_case_v arg
@@ -345,12 +357,12 @@ and pp_syntax_expr fmt (value : value) : unit =
   | ( "expression",
       [ []; [ "<" ]; [ ">"; "(" ]; [ ")" ] ],
       [ func; type_args; args ] ) ->
-      F.fprintf fmt "(%a)<%a>(%a)" pp_case_v func (pp_list_v ~sep:Comma)
-        type_args (pp_list_v ~sep:Comma) args
+      F.fprintf fmt "(%a)<%a>(%a)" pp_case_v func (pp_list_v ~level:0) type_args
+        (pp_list_v ~level:0) args
   | "expression", [ []; [ "(" ]; [ ")" ] ], [ func; args ] ->
-      F.fprintf fmt "(%a)(%a)" pp_case_v func (pp_list_v ~sep:Comma) args
+      F.fprintf fmt "(%a)(%a)" pp_case_v func (pp_list_v ~level:0) args
   | "expression", [ []; [ "(" ]; [ ")"; "PHTM_6" ] ], [ typ; args ] ->
-      F.fprintf fmt "(%a)(%a)" pp_case_v typ (pp_list_v ~sep:Comma) args
+      F.fprintf fmt "(%a)(%a)" pp_case_v typ (pp_list_v ~level:0) args
   | "expression", _, _ ->
       failwith
         (F.asprintf "@pp_syntax_expr: ill-formed expression:\n%a" pp_case_v
@@ -387,7 +399,7 @@ and pp_syntax_keyset_expr fmt (value : value) : unit =
             %a"
            pp_case_v value)
   | "tupleKeysetExpression", [ [ "(" ]; [ "," ]; [ ")" ] ], [ expr; exprs ] ->
-      F.fprintf fmt "(%a, %a)" pp_case_v expr (pp_list_v ~sep:Comma) exprs
+      F.fprintf fmt "(%a, %a)" pp_case_v expr (pp_list_v ~level:0) exprs
   | "tupleKeysetExpression", [ [ "(" ]; [ ")"; "PHTM_19" ] ], [ expr ] ->
       F.fprintf fmt "(%a)" pp_case_v expr
   | "tupleKeysetExpression", _, _ ->
@@ -467,9 +479,82 @@ and pp_syntax_init fmt (value : value) : unit =
         (Printf.sprintf "@pp_syntax_init: expected initializer, got %s"
            (id_of_case_v value))
 
-and pp_syntax_stmt _fmt (value : value) : unit =
+and pp_syntax_stmt' ~level fmt (value : value) : unit =
+  let is_assign_op = function
+    | "=" | "+=" | "|+|=" | "-=" | "|-|=" | "*=" | "/=" | "%=" | "<<=" | ">>="
+    | "&=" | "^=" | "|=" ->
+        true
+    | _ -> false
+  in
   match flatten_case_v value with
-  | _ -> failwith "@pp_syntax_stmt: not yet implemented"
+  | ( "assignmentOrMethodCallStatementWithoutSemicolon",
+      [ []; [ "(" ]; [ ")" ] ],
+      [ func; args ] ) ->
+      F.fprintf fmt "%a(%a)" pp_case_v func (pp_list_v ~level) args
+  | ( "assignmentOrMethodCallStatementWithoutSemicolon",
+      [ []; [ "<" ]; [ ">"; "(" ]; [ ")" ] ],
+      [ func; targs; args ] ) ->
+      F.fprintf fmt "%a<%a>(%a)" pp_case_v func (pp_list_v ~level) targs
+        (pp_list_v ~level) args
+  | ( "assignmentOrMethodCallStatementWithoutSemicolon",
+      [ []; [ assign_op ]; [] ],
+      [ lhs; rhs ] )
+    when is_assign_op assign_op ->
+      F.fprintf fmt "%a %s (%a)" pp_case_v lhs assign_op pp_case_v rhs
+  | "assignmentOrMethodCallStatementWithoutSemicolon", _, _ ->
+      failwith
+        (F.asprintf "@pp_syntax_stmt': ill-formed statement helper:\n%a"
+           pp_case_v value)
+  | "switchLabel", [ [ "DEFAULT" ] ], [] -> F.fprintf fmt "default"
+  | "switchCase", [ []; [ ":" ]; [] ], [ label; code ] ->
+      F.fprintf fmt "%a: %a" pp_case_v label (pp_syntax_stmt ~level) code
+  | "switchCase", [ []; [ ":" ] ], [ label ] ->
+      F.fprintf fmt "%a:" pp_case_v label
+  | "forCollectionExpr", [ []; [ ".." ]; [] ], [ expr_l; expr_r ] ->
+      F.fprintf fmt "(%a)..(%a)" pp_case_v expr_l pp_case_v expr_r
+  | _ ->
+      failwith
+        (Printf.sprintf "@pp_syntax_stmt': expected statement helper, got %s"
+           (id_of_case_v value))
+
+and pp_syntax_stmt ~level fmt (value : value) : unit =
+  match flatten_case_v value with
+  | "assignmentOrMethodCallStatement", [ []; [ ";" ] ], [ stmt' ] ->
+      F.fprintf fmt "%a;" pp_case_v stmt'
+  | ( "directApplication",
+      [ []; [ "."; "APPLY"; "(" ]; [ ")"; ";" ] ],
+      [ named_type; args ] ) ->
+      F.fprintf fmt "%a.apply(%a);" pp_case_v named_type (pp_list_v ~level) args
+  | "conditionalStatement", [ [ "IF"; "(" ]; [ ")" ]; [] ], [ cond; tru ] ->
+      F.fprintf fmt "if (%a) %a" pp_case_v cond (pp_syntax_stmt ~level) tru
+  | "emptyStatement", [ [ ";" ] ], [] -> F.fprintf fmt ";"
+  | "blockStatement", [ []; [ "{" ]; [ "}" ] ], [ annos; stmts ] ->
+      F.fprintf fmt "%a{\n%a\n%s}" (pp_opt_v ~postfix:" ") annos
+        (pp_list_v ~level:(level + 1))
+        stmts (indent level)
+  | "returnStatement", [ [ "RETURN"; ";" ] ], [] -> F.fprintf fmt "return;"
+  | "returnStatement", [ [ "RETURN" ]; [ ";" ] ], [ expr ] ->
+      F.fprintf fmt "return %a;" pp_case_v expr
+  | "breakStatement", [ [ "BREAK"; ";" ] ], [] -> F.fprintf fmt "break;"
+  | "continueStatement", [ [ "CONTINUE"; ";" ] ], [] ->
+      F.fprintf fmt "continue;"
+  | "exitStatement", [ [ "EXIT"; ";" ] ], [] -> F.fprintf fmt "exit;"
+  | ( "switchStatement",
+      [ [ "SWITCH"; "(" ]; [ ")"; "{" ]; [ "}" ] ],
+      [ expr; cases ] ) ->
+      F.fprintf fmt "switch (%a) {\n%a\n%s}" pp_case_v expr (pp_list_v ~level)
+        cases (indent level)
+  | ( "forStatement",
+      [ []; [ "FOR"; "(" ]; [ ";" ]; [ ";" ]; [ ")" ]; [] ],
+      [ anno; init; cond; update; body ] ) ->
+      F.fprintf fmt "%afor (%a; %a; %a) %a"
+        (pp_opt_v ~postfix:(F.sprintf "\n%s" (indent level)))
+        anno (pp_list_v ~level:0) init pp_case_v cond (pp_list_v ~level:0)
+        update (pp_syntax_stmt ~level) body
+  | _ ->
+      failwith
+        (Printf.sprintf "@pp_syntax_stmt: expected statement, got %s"
+           (id_of_case_v value))
 
 and pp_syntax_mthd fmt (value : value) : unit =
   match flatten_case_v value with
@@ -499,19 +584,44 @@ and pp_syntax_block fmt (value : value) : unit =
         (Printf.sprintf "@pp_syntax_block: expected block, got %s"
            (id_of_case_v value))
 
-and pp_syntax_decls ~level fmt (value : value) : unit =
-  match value.it with
-  | ListV values -> pp_list ~level (pp_syntax_decl ~level) ~sep:Nl fmt values
+and pp_syntax_stat_or_decl ~level fmt (value : value) : unit =
+  match id_of_case_v value with
+  | "variableDeclaration" | "constantDeclaration" ->
+      pp_syntax_decl ~level fmt value
+  | "assignmentOrMethodCallStatement" | "directApplication"
+  | "conditionalStatement" | "emptyStatement" | "blockStatement"
+  | "returnStatement" | "breakStatement" | "continueStatement" | "exitStatement"
+  | "switchStatement" | "forStatement" ->
+      pp_syntax_stmt ~level fmt value
   | _ ->
       failwith
-        (F.asprintf "@pp_syntax_decls: expected ListV, got %a" pp_value value)
+        (Printf.sprintf
+           "@pp_syntax_stat_or_decl: expected variable declaration, constant \
+            declaration, or statement, got %s"
+           (id_of_case_v value))
+
+and pp_syntax_decl_or_assign_or_call_stmt fmt (value : value) : unit =
+  match id_of_case_v value with
+  | "variableDeclarationWithoutSemicolon" -> pp_case_v fmt value
+  | "assignmentOrMethodCallStatementWithoutSemicolon" ->
+      pp_syntax_stmt' ~level:0 fmt value
+  | _ ->
+      failwith
+        (Printf.sprintf
+           "@pp_syntax_decl_or_assign_or_call_stmt: expected variable \
+            declaration, assignment statement, or method call statement, got \
+            %s"
+           (id_of_case_v value))
 
 and pp_syntax_decl ~level fmt (value : value) : unit =
   match flatten_case_v value with
   | ( "constantDeclaration",
       [ []; [ "CONST" ]; []; []; [ ";" ] ],
-      [ _optAnnotations; _typeRef; _name; _init ] ) ->
-      F.fprintf fmt ""
+      [ opt_annos; type_ref; name; opt_init ] ) ->
+      F.fprintf fmt "%aconst %a %a%a;" (pp_opt_v ~postfix:" ") opt_annos
+        pp_case_v type_ref pp_case_v name (pp_opt_v ~postfix:"") opt_init
+  | "variableDeclaration", [ []; [ ";" ] ], [ decl ] ->
+      F.fprintf fmt "%a;" pp_case_v decl
   | "errorDeclaration", _, _
   | "matchKindDeclaration", _, _
   | ( "externDeclaration",
@@ -529,7 +639,7 @@ and pp_syntax_decl ~level fmt (value : value) : unit =
     ->
       F.fprintf fmt "%a%a {\n%a\n%sapply %a\n%s}" pp_default_case_v
         control_type_decl pp_value opt_constructor_params
-        (pp_syntax_decls ~level:(level + 1))
+        (pp_list_v ~level:(level + 1))
         control_local_decls
         (indent (level + 1))
         pp_syntax_block body (indent level)
@@ -576,15 +686,21 @@ and pp_case_v' fmt (value : value) : unit =
   (* Key value pair *)
   | "kvPair", [ []; [ "=" ]; [] ], [ key; value ] ->
       F.fprintf fmt "(%a) = (%a)" pp_case_v key pp_case_v value
+  (* Declarations *)
+  | ( "variableDeclarationWithoutSemicolon",
+      [ []; []; []; []; [] ],
+      [ opt_anno; type_ref; name; opt_init ] ) ->
+      F.fprintf fmt "%a%a %a%a" (pp_opt_v ~postfix:" ") opt_anno pp_case_v
+        type_ref pp_case_v name (pp_opt_v ~postfix:"") opt_init
   | _ -> pp_default_case_v fmt value
 
 and pp_case_v fmt (value : value) : unit =
   match id_of_case_v value with
-  | "constantDeclaration" | "errorDeclaration" | "matchKindDeclaration"
-  | "externDeclaration" | "instantiation" | "functionDeclaration"
-  | "actionDeclaration" | "parserDeclaration" | "controlDeclaration"
-  | "headerTypeDeclaration" | "headerUnionDeclaration" | "structTypeDeclaration"
-  | "enumDeclaration" | "typeDeclaration" ->
+  | "constantDeclaration" | "variableDeclaration" | "errorDeclaration"
+  | "matchKindDeclaration" | "externDeclaration" | "instantiation"
+  | "functionDeclaration" | "actionDeclaration" | "parserDeclaration"
+  | "controlDeclaration" | "headerTypeDeclaration" | "headerUnionDeclaration"
+  | "structTypeDeclaration" | "enumDeclaration" | "typeDeclaration" ->
       pp_syntax_decl ~level:0 fmt value
   | "nonTypeName" | "name" | "prefixedNonTypeName" | "prefixedType" ->
       pp_syntax_name fmt value
@@ -604,4 +720,12 @@ and pp_case_v fmt (value : value) : unit =
   | "realTypeArg" | "typeArg" -> pp_syntax_targ fmt value
   | "argument" -> pp_syntax_arg fmt value
   | "lvalue" -> pp_syntax_lvalue fmt value
+  | "assignmentOrMethodCallStatementWithoutSemicolon" | "switchLabel"
+  | "switchCase" | "forCollectionExpr" ->
+      pp_syntax_stmt' ~level:0 fmt value
+  | "assignmentOrMethodCallStatement" | "directApplication"
+  | "conditionalStatement" | "emptyStatement" | "blockStatement"
+  | "returnStatement" | "breakStatement" | "continueStatement" | "exitStatement"
+  | "switchStatement" | "forStatement" ->
+      pp_syntax_stmt ~level:0 fmt value
   | _ -> pp_case_v' fmt value

--- a/p4spec/lib/parsing/pp.ml
+++ b/p4spec/lib/parsing/pp.ml
@@ -91,6 +91,8 @@ and pp_list_v ?(level = 0) ~sep fmt (value : value) : unit =
       pp_list (pp_syntax_stmt' ~level:0) ~sep fmt values
   | "statementOrDeclaration" ->
       pp_list ~level (pp_syntax_stat_or_decl ~level) ~sep fmt values
+  | "methodPrototype" -> pp_list ~level (pp_syntax_mthd ~level) ~sep fmt values
+  | "objDeclaration" -> pp_list ~level (pp_syntax_decl ~level) ~sep fmt values
   | "declaration" when List.compare_length_with values 0 = 0 ->
       F.fprintf fmt ";"
   | "declaration" -> pp_list ~level (pp_syntax_decl ~level) ~sep fmt values
@@ -616,12 +618,24 @@ and pp_syntax_func fmt (value : value) : unit =
         (Printf.sprintf "@pp_syntax_func: expected function prototype, got %s"
            (id_of_case_v value))
 
-and pp_syntax_mthd fmt (value : value) : unit =
+and pp_syntax_mthd ~level fmt (value : value) : unit =
   match flatten_case_v value with
-  | "methodPrototype", [ []; []; [ ";" ] ], [ _anno; _func ]
-  | "methodPrototype", [ []; [ "ABSTRACT" ]; [ ";" ] ], [ _anno; _func ]
-  | "methodPrototype", [ []; []; [ "(" ]; [ ")"; ";" ] ], [ _anno; _; _func ] ->
-      pp_default_case_v fmt value
+  | "methodPrototype", [ []; []; [ ";" ] ], [ opt_annos; func ] ->
+      F.fprintf fmt "%a%a;"
+        (pp_opt_annos ~level ~sep:Nl)
+        opt_annos pp_case_v func
+  | "methodPrototype", [ []; [ "ABSTRACT" ]; [ ";" ] ], [ opt_annos; func ] ->
+      F.fprintf fmt "%aabstract %a;"
+        (pp_opt_annos ~level ~sep:Nl)
+        opt_annos pp_case_v func
+  | ( "methodPrototype",
+      [ []; []; [ "(" ]; [ ")"; ";" ] ],
+      [ opt_annos; tid; params ] ) ->
+      F.fprintf fmt "%a%a(%a);"
+        (pp_opt_annos ~level ~sep:Nl)
+        opt_annos pp_case_v tid
+        (pp_list_v ~level:0 ~sep:Comma)
+        params
   | "methodPrototype", _, _ ->
       failwith
         (F.asprintf "@pp_syntax_method: ill-formed methodPrototype:\n%a"
@@ -660,6 +674,21 @@ and pp_syntax_decl_or_assign_or_call_stmt fmt (value : value) : unit =
             %s"
            (id_of_case_v value))
 
+and pp_syntax_obj_init ~level fmt (value : value) : unit =
+  match flatten_case_v value with
+  | "objInitializer", [ [ "="; "{" ]; [ "}" ] ], [ decls ] ->
+      F.fprintf fmt " = {\n%a\n%s}" (pp_list_v ~level ~sep:Nl) decls
+        (indent level)
+  | "objInitializer", _, _ ->
+      failwith
+        (F.asprintf "@pp_syntax_obj_init: ill-formed object initializer:\n%a"
+           pp_case_v value)
+  | _ ->
+      failwith
+        (Printf.sprintf
+           "@pp_syntax_obj_init: expected object initializer, got %s"
+           (id_of_case_v value))
+
 and pp_syntax_decl ~level fmt (value : value) : unit =
   match flatten_case_v value with
   | ( "constantDeclaration",
@@ -686,13 +715,48 @@ and pp_syntax_decl ~level fmt (value : value) : unit =
         comma (indent level)
   | ( "externDeclaration",
       [ []; [ "EXTERN" ]; []; [ "{" ]; [ "}" ] ],
-      [ _; _; _; _ ] )
-  | "externDeclaration", _, _
-  | "instantiation", _, _
-  | "functionDeclaration", [ []; []; []; [] ], [ _; _; _ ]
-  | "actionDeclaration", _, _
-  | "parserDeclaration", _, _ ->
-      pp_default_case_v fmt value
+      [ opt_annos; name; opt_tparams; mthds ] ) ->
+      F.fprintf fmt "%aextern %a%a {%a}"
+        (pp_opt_annos ~level ~sep:Nl)
+        opt_annos pp_case_v name
+        (pp_opt_v ~postfix:"" pp_case_v)
+        opt_tparams (pp_list_v ~level ~sep:Nl) mthds
+  | "externDeclaration", [ []; [ "EXTERN" ]; [ ";" ] ], [ opt_annos; func ] ->
+      F.fprintf fmt "%aextern %a;"
+        (pp_opt_annos ~level ~sep:Nl)
+        opt_annos pp_case_v func
+  | "functionDeclaration", [ []; []; []; [] ], [ opt_annos; func; body ] ->
+      F.fprintf fmt "%a%a %a"
+        (pp_opt_annos ~level ~sep:Nl)
+        opt_annos pp_case_v func (pp_syntax_stmt ~level) body
+  | ( "instantiation",
+      [ []; []; [ "(" ]; [ ")" ]; [ ";" ] ],
+      [ opt_annos; type_ref; args; name ] ) ->
+      F.fprintf fmt "%a%a(%a) %a;"
+        (pp_opt_annos ~level ~sep:Nl)
+        opt_annos pp_case_v type_ref
+        (pp_list_v ~level:0 ~sep:Comma)
+        args pp_case_v name
+  | ( "instantiation",
+      [ []; []; [ "(" ]; [ ")" ]; []; [ ";" ] ],
+      [ opt_annos; type_ref; args; name; init ] ) ->
+      F.fprintf fmt "%a%a(%a) %a%a"
+        (pp_opt_annos ~level ~sep:Nl)
+        opt_annos pp_case_v type_ref
+        (pp_list_v ~level:0 ~sep:Comma)
+        args pp_case_v name
+        (pp_syntax_obj_init ~level)
+        init
+  | ( "actionDeclaration",
+      [ []; [ "ACTION" ]; [ "(" ]; [ ")" ]; [] ],
+      [ opt_annos; name; params; body ] ) ->
+      F.fprintf fmt "%aaction %a(%a) %a"
+        (pp_opt_annos ~level ~sep:Nl)
+        opt_annos pp_case_v name
+        (pp_list_v ~level:0 ~sep:Comma)
+        params (pp_syntax_stmt ~level) body
+  | "tableDeclaration", _, _ -> pp_default_case_v fmt value
+  | "parserDeclaration", _, _ -> pp_default_case_v fmt value
   | ( "controlDeclaration",
       [ []; []; [ "{" ]; [ "APPLY" ]; [ "}" ] ],
       [ control_type_decl; opt_constructor_params; control_local_decls; body ] )
@@ -718,8 +782,6 @@ and pp_syntax_decl ~level fmt (value : value) : unit =
   | "typeDeclaration", [ []; [ ";"; "PHTM_13" ] ], [ _ ]
   | "typeDeclaration", [ []; [ ";"; "PHTM_14" ] ], [ _ ]
   | "typeDeclaration", [ []; [ ";"; "PHTM_15" ] ], [ _ ]
-  | "tableDeclaration", _, _ ->
-      pp_default_case_v fmt value
   | _ ->
       failwith
         (Printf.sprintf "@pp_syntax_decl: expected declaration, got %s"
@@ -788,6 +850,7 @@ and pp_case_v fmt (value : value) : unit =
   | "realTypeArg" | "typeArg" -> pp_syntax_targ fmt value
   | "argument" -> pp_syntax_arg fmt value
   | "lvalue" -> pp_syntax_lvalue fmt value
+  | "initializer" -> pp_syntax_init fmt value
   | "assignmentOrMethodCallStatementWithoutSemicolon" | "switchLabel"
   | "switchCase" | "forCollectionExpr" ->
       pp_syntax_stmt' ~level:0 fmt value
@@ -797,4 +860,5 @@ and pp_case_v fmt (value : value) : unit =
   | "switchStatement" | "forStatement" ->
       pp_syntax_stmt ~level:0 fmt value
   | "functionPrototype" -> pp_syntax_func fmt value
+  | "methodPrototype" -> pp_syntax_mthd ~level:0 fmt value
   | _ -> pp_case_v' fmt value

--- a/p4spec/lib/parsing/pp.ml
+++ b/p4spec/lib/parsing/pp.ml
@@ -84,7 +84,7 @@ and pp_list_v ?(level = 0) ~sep fmt (value : value) : unit =
   | "identifier" | "typeParameterList" | "parameter" | "expression" | "kvPair"
   | "simpleKeysetExpression" | "realTypeArg" | "typeArg" | "argument"
   | "keyElement" | "action" | "entry" | "selectCase" | "specifiedIdentifier"
-  | "structField" | "annotation" | "simpleAnnotation" ->
+  | "structField" | "simpleAnnotation" ->
       pp_list ~level pp_case_v ~sep fmt values
   | "switchCase" -> pp_list ~level (pp_syntax_stmt' ~level) ~sep fmt values
   | "declOrAssignmentOrMethodCallStatement" ->
@@ -102,6 +102,7 @@ and pp_list_v ?(level = 0) ~sep fmt (value : value) : unit =
       pp_list ~level (pp_syntax_parser_stmt ~level) ~sep fmt values
   | "parserState" ->
       pp_list ~level (pp_syntax_parser_state ~level) ~sep fmt values
+  | "annotation" -> pp_list_no_start_indent ~level pp_case_v ~sep fmt values
   | "declaration" when List.compare_length_with values 0 = 0 ->
       F.fprintf fmt ";"
   | "declaration" -> pp_list ~level (pp_syntax_decl ~level) ~sep fmt values
@@ -606,6 +607,22 @@ and pp_syntax_stmt ~level fmt (value : value) : unit =
         init pp_case_v cond
         (pp_list_v ~level:0 ~sep:Comma)
         update (pp_syntax_stmt ~level) body
+  | ( "forStatement",
+      [ []; [ "FOR"; "(" ]; []; [ "IN" ]; [ ")" ]; [] ],
+      [ opt_annos; typ; name; collection; body ] ) ->
+      F.fprintf fmt "%afor (%a %a in %a) %a"
+        (pp_opt_annos ~level ~sep:Nl)
+        opt_annos pp_case_v typ pp_case_v name pp_case_v collection
+        (pp_syntax_stmt ~level) body
+  | ( "forStatement",
+      [ []; [ "FOR"; "(" ]; []; []; [ "IN" ]; [ ")" ]; [] ],
+      [ opt_annos; opt_annos_in; typ; name; collection; body ] ) ->
+      F.fprintf fmt "%afor (%a%a %a in %a) %a"
+        (pp_opt_annos ~level ~sep:Nl)
+        opt_annos
+        (pp_opt_annos ~level:0 ~sep:SpaceSep)
+        opt_annos_in pp_case_v typ pp_case_v name pp_case_v collection
+        (pp_syntax_stmt ~level) body
   | _ ->
       failwith
         (Printf.sprintf "@pp_syntax_stmt: expected statement, got %s"
@@ -812,7 +829,7 @@ and pp_syntax_table_prop ~level fmt (value : value) : unit =
   | ( "tableProperty",
       [ []; []; []; []; [ ";" ] ],
       [ opt_annos; opt_const; name; init ] ) ->
-      F.fprintf fmt "%a%a%a%a"
+      F.fprintf fmt "%a%a%a%a;"
         (pp_opt_annos ~level ~sep:Nl)
         opt_annos
         (pp_opt_v ~postfix:" " pp_case_v)
@@ -1208,6 +1225,155 @@ and pp_syntax_decl ~level fmt (value : value) : unit =
         (Printf.sprintf "@pp_syntax_decl: expected declaration, got %s"
            (id_of_case_v value))
 
+and pp_syntax_anno_token fmt (value : value) : unit =
+  match flatten_case_v value with
+  | "annotationToken", [ [ "UNEXPECTED_TOKEN" ] ], [] ->
+      F.fprintf fmt "unexpected_token"
+  | "annotationToken", [ [ "ABSTRACT" ] ], [] -> F.fprintf fmt "abstract"
+  | "annotationToken", [ [ "ACTION" ] ], [] -> F.fprintf fmt "action"
+  | "annotationToken", [ [ "ACTIONS" ] ], [] -> F.fprintf fmt "actions"
+  | "annotationToken", [ [ "APPLY" ] ], [] -> F.fprintf fmt "apply"
+  | "annotationToken", [ [ "BOOL" ] ], [] -> F.fprintf fmt "bool"
+  | "annotationToken", [ [ "BIT" ] ], [] -> F.fprintf fmt "bit"
+  | "annotationToken", [ [ "BREAK" ] ], [] -> F.fprintf fmt "break"
+  | "annotationToken", [ [ "CONST" ] ], [] -> F.fprintf fmt "const"
+  | "annotationToken", [ [ "CONTINUE" ] ], [] -> F.fprintf fmt "continue"
+  | "annotationToken", [ [ "CONTROL" ] ], [] -> F.fprintf fmt "control"
+  | "annotationToken", [ [ "DEFAULT" ] ], [] -> F.fprintf fmt "default"
+  | "annotationToken", [ [ "ELSE" ] ], [] -> F.fprintf fmt "else"
+  | "annotationToken", [ [ "ENTRIES" ] ], [] -> F.fprintf fmt "entries"
+  | "annotationToken", [ [ "ENUM" ] ], [] -> F.fprintf fmt "enum"
+  | "annotationToken", [ [ "ERROR" ] ], [] -> F.fprintf fmt "error"
+  | "annotationToken", [ [ "EXIT" ] ], [] -> F.fprintf fmt "exit"
+  | "annotationToken", [ [ "EXTERN" ] ], [] -> F.fprintf fmt "extern"
+  | "annotationToken", [ [ "FALSE" ] ], [] -> F.fprintf fmt "false"
+  | "annotationToken", [ [ "FOR" ] ], [] -> F.fprintf fmt "for"
+  | "annotationToken", [ [ "HEADER" ] ], [] -> F.fprintf fmt "header"
+  | "annotationToken", [ [ "HEADER_UNION" ] ], [] ->
+      F.fprintf fmt "header_union"
+  | "annotationToken", [ [ "IF" ] ], [] -> F.fprintf fmt "if"
+  | "annotationToken", [ [ "IN" ] ], [] -> F.fprintf fmt "in"
+  | "annotationToken", [ [ "INOUT" ] ], [] -> F.fprintf fmt "inout"
+  | "annotationToken", [ [ "INT" ] ], [] -> F.fprintf fmt "int"
+  | "annotationToken", [ [ "KEY" ] ], [] -> F.fprintf fmt "key"
+  | "annotationToken", [ [ "MATCH_KIND" ] ], [] -> F.fprintf fmt "match_kind"
+  | "annotationToken", [ [ "TYPE" ] ], [] -> F.fprintf fmt "type"
+  | "annotationToken", [ [ "OUT" ] ], [] -> F.fprintf fmt "out"
+  | "annotationToken", [ [ "PARSER" ] ], [] -> F.fprintf fmt "parser"
+  | "annotationToken", [ [ "PACKAGE" ] ], [] -> F.fprintf fmt "package"
+  | "annotationToken", [ [ "PRAGMA" ] ], [] -> F.fprintf fmt "pragma"
+  | "annotationToken", [ [ "RETURN" ] ], [] -> F.fprintf fmt "return"
+  | "annotationToken", [ [ "SELECT" ] ], [] -> F.fprintf fmt "select"
+  | "annotationToken", [ [ "STATE" ] ], [] -> F.fprintf fmt "state"
+  | "annotationToken", [ [ "STRING" ] ], [] -> F.fprintf fmt "string"
+  | "annotationToken", [ [ "STRUCT" ] ], [] -> F.fprintf fmt "struct"
+  | "annotationToken", [ [ "SWITCH" ] ], [] -> F.fprintf fmt "switch"
+  | "annotationToken", [ [ "TABLE" ] ], [] -> F.fprintf fmt "table"
+  | "annotationToken", [ [ "THIS" ] ], [] -> F.fprintf fmt "this"
+  | "annotationToken", [ [ "TRANSITION" ] ], [] -> F.fprintf fmt "transition"
+  | "annotationToken", [ [ "TRUE" ] ], [] -> F.fprintf fmt "true"
+  | "annotationToken", [ [ "TUPLE" ] ], [] -> F.fprintf fmt "tuple"
+  | "annotationToken", [ [ "TYPEDEF" ] ], [] -> F.fprintf fmt "typedef"
+  | "annotationToken", [ [ "VARBIT" ] ], [] -> F.fprintf fmt "varbit"
+  | "annotationToken", [ [ "VALUESET" ] ], [] -> F.fprintf fmt "valueset"
+  | "annotationToken", [ [ "LIST" ] ], [] -> F.fprintf fmt "list"
+  | "annotationToken", [ [ "VOID" ] ], [] -> F.fprintf fmt "void"
+  | "annotationToken", [ [ "_" ] ], [] -> F.fprintf fmt "_"
+  | "annotationToken", [ [ "&&&" ] ], [] -> F.fprintf fmt "&&&"
+  | "annotationToken", [ [ ".." ] ], [] -> F.fprintf fmt ".."
+  | "annotationToken", [ [ "<<" ] ], [] -> F.fprintf fmt "<<"
+  | "annotationToken", [ [ "&&" ] ], [] -> F.fprintf fmt "&&"
+  | "annotationToken", [ [ "||" ] ], [] -> F.fprintf fmt "||"
+  | "annotationToken", [ [ "==" ] ], [] -> F.fprintf fmt "=="
+  | "annotationToken", [ [ "!=" ] ], [] -> F.fprintf fmt "!="
+  | "annotationToken", [ [ ">=" ] ], [] -> F.fprintf fmt ">="
+  | "annotationToken", [ [ "<=" ] ], [] -> F.fprintf fmt "<="
+  | "annotationToken", [ [ "++" ] ], [] -> F.fprintf fmt "++"
+  | "annotationToken", [ [ "+" ] ], [] -> F.fprintf fmt "+"
+  | "annotationToken", [ [ "|+|" ] ], [] -> F.fprintf fmt "|+|"
+  | "annotationToken", [ [ "-" ] ], [] -> F.fprintf fmt "-"
+  | "annotationToken", [ [ "|-|" ] ], [] -> F.fprintf fmt "|-|"
+  | "annotationToken", [ [ "*" ] ], [] -> F.fprintf fmt "*"
+  | "annotationToken", [ [ "/" ] ], [] -> F.fprintf fmt "/"
+  | "annotationToken", [ [ "%" ] ], [] -> F.fprintf fmt "%%"
+  | "annotationToken", [ [ "|" ] ], [] -> F.fprintf fmt "|"
+  | "annotationToken", [ [ "&" ] ], [] -> F.fprintf fmt "&"
+  | "annotationToken", [ [ "^" ] ], [] -> F.fprintf fmt "^"
+  | "annotationToken", [ [ "~" ] ], [] -> F.fprintf fmt "~"
+  | "annotationToken", [ [ "[" ] ], [] -> F.fprintf fmt "["
+  | "annotationToken", [ [ "]" ] ], [] -> F.fprintf fmt "]"
+  | "annotationToken", [ [ "{" ] ], [] -> F.fprintf fmt "{"
+  | "annotationToken", [ [ "}" ] ], [] -> F.fprintf fmt "}"
+  | "annotationToken", [ [ "<" ] ], [] -> F.fprintf fmt "<"
+  | "annotationToken", [ [ ">" ] ], [] -> F.fprintf fmt ">"
+  | "annotationToken", [ [ "!" ] ], [] -> F.fprintf fmt "!"
+  | "annotationToken", [ [ ":" ] ], [] -> F.fprintf fmt ":"
+  | "annotationToken", [ [ ","; "PHTM_21" ] ], [] -> F.fprintf fmt ","
+  | "annotationToken", [ [ "?" ] ], [] -> F.fprintf fmt "?"
+  | "annotationToken", [ [ "." ] ], [] -> F.fprintf fmt "."
+  | "annotationToken", [ [ "=" ] ], [] -> F.fprintf fmt "="
+  | "annotationToken", [ [ ";" ] ], [] -> F.fprintf fmt ";"
+  | "annotationToken", [ [ "@" ] ], [] -> F.fprintf fmt "@"
+  | "annotationToken", _, _ ->
+      failwith
+        (F.asprintf "@pp_syntax_anno_token: ill-formed annotation token:\n%a"
+           pp_case_v value)
+  | _ ->
+      failwith
+        (Printf.sprintf
+           "@pp_syntax_anno_token: expected annotation token, got %s"
+           (id_of_case_v value))
+
+and pp_syntax_struct_anno_body fmt (value : value) : unit =
+  match flatten_case_v value with
+  | "structuredAnnotationBody", [ []; []; [] ], [ exprs; opt_comma ] ->
+      F.fprintf fmt "%a%a"
+        (pp_list_v ~level:0 ~sep:Comma)
+        exprs
+        (pp_opt_v ~postfix:"" pp_case_v)
+        opt_comma
+  | "structuredAnnotationBody", [ []; []; [ "PHTM_20" ] ], [ kvs; opt_comma ] ->
+      F.fprintf fmt "%a%a"
+        (pp_list_v ~level:0 ~sep:Comma)
+        kvs
+        (pp_opt_v ~postfix:"" pp_case_v)
+        opt_comma
+  | "structuredAnnotationBody", _, _ ->
+      failwith
+        (F.asprintf
+           "@pp_syntax_struct_anno_body: ill-formed structured annotation body:\n\
+            %a"
+           pp_case_v value)
+  | _ ->
+      failwith
+        (Printf.sprintf
+           "@pp_syntax_struct_anno_body: expected structured annotation body, \
+            got %s"
+           (id_of_case_v value))
+
+and pp_syntax_anno fmt (value : value) : unit =
+  match flatten_case_v value with
+  | "annotation", [ [ "@" ]; [] ], [ name ] ->
+      F.fprintf fmt "@%a" pp_case_v name
+  | "annotation", [ [ "@" ]; [ "(" ]; [ ")" ] ], [ name; body ] ->
+      F.fprintf fmt "@%a(%a)" pp_case_v name
+        (pp_list_v ~level:0 ~sep:Comma)
+        body
+  | "annotation", [ [ "@" ]; [ "[" ]; [ "]" ] ], [ name; body ] ->
+      F.fprintf fmt "@%a[%a]" pp_case_v name pp_case_v body
+  | "annotation", [ [ "PRAGMA" ]; []; [ "PRAGMA_END" ] ], [ name; body ] ->
+      F.fprintf fmt "@pragma %a %a" pp_case_v name
+        (pp_list_v ~level:0 ~sep:SpaceSep)
+        body
+  | "annotation", _, _ ->
+      failwith
+        (F.asprintf "@pp_syntax_anno: ill-formed annotation:\n%a" pp_case_v
+           value)
+  | _ ->
+      failwith
+        (Printf.sprintf "@pp_syntax_anno: expected annotation, got %s"
+           (id_of_case_v value))
+
 and pp_opt_annos ?(level = 0) ~sep fmt (value : value) : unit =
   let postfix = if is_nl sep then F.sprintf "\n%s" (indent level) else " " in
   pp_opt_v ~postfix (pp_list_v ~level ~sep) fmt value
@@ -1226,7 +1392,7 @@ and pp_case_v' fmt (value : value) : unit =
       F.fprintf fmt "%aw%a" pp_value value_width pp_value value_int
   (* Strings *)
   | "stringLiteral", [ []; [ "PHTM_2" ] ], [ value_text ] ->
-      pp_value fmt value_text
+      F.fprintf fmt "\"%a\"" pp_text_v value_text
   (* Names *)
   | "dotPrefix", [ [ "." ] ], [] -> F.fprintf fmt "."
   (* Type references *)
@@ -1249,6 +1415,9 @@ and pp_case_v' fmt (value : value) : unit =
       F.fprintf fmt "%a%a %a;"
         (pp_opt_annos ~level:0 ~sep:SpaceSep)
         opt_annos pp_case_v type_ref pp_case_v name
+  (* Annotations *)
+  | "simpleAnnotation", [ [ "(" ]; [ ")" ] ], [ body ] ->
+      F.fprintf fmt "(%a)" (pp_list_v ~level:0 ~sep:Comma) body
   | _ -> pp_default_case_v fmt value
 
 and pp_case_v fmt (value : value) : unit =
@@ -1304,4 +1473,7 @@ and pp_case_v fmt (value : value) : unit =
   | "parserState" -> pp_syntax_parser_state ~level:0 fmt value
   | "parserTypeDeclaration" -> pp_syntax_parser_type_decl ~level:0 fmt value
   | "packageTypeDeclaration" -> pp_syntax_pckg_type_decl ~level:0 fmt value
+  | "annotationToken" -> pp_syntax_anno_token fmt value
+  | "structuredAnnotationBody" -> pp_syntax_struct_anno_body fmt value
+  | "annotation" -> pp_syntax_anno fmt value
   | _ -> pp_case_v' fmt value

--- a/p4spec/lib/parsing/pp.ml
+++ b/p4spec/lib/parsing/pp.ml
@@ -425,7 +425,7 @@ and pp_syntax_params fmt (value : value) : unit =
       failwith
         (F.asprintf "@pp_syntax_params: ill-formed parameter:\n%a" pp_case_v
            value)
-  (** Constructor parameters **)
+  (* Constructor parameters *)
   | "constructorParameters", [ [ "(" ]; [ ")" ] ], [ params ] ->
       F.fprintf fmt "(%a)" (pp_list_v ~level:0 ~sep:Comma) params
   | _ ->
@@ -713,6 +713,39 @@ and pp_syntax_init fmt (value : value) : unit =
         (Printf.sprintf "@pp_syntax_init: expected initializer, got %s"
            (id_of_case_v value))
 
+(* Statements in for init statements *)
+
+and pp_syntax_decl_or_assign_or_call_stmt fmt (value : value) : unit =
+  match id_of_case_v value with
+  | "variableDeclarationWithoutSemicolon" -> pp_case_v fmt value
+  | "assignmentOrMethodCallStatementWithoutSemicolon" ->
+      pp_syntax_stmt ~level:0 fmt value
+  | _ ->
+      failwith
+        (Printf.sprintf
+           "@pp_syntax_decl_or_assign_or_call_stmt: expected variable \
+            declaration, assignment statement, or method call statement, got \
+            %s"
+           (id_of_case_v value))
+
+(* Statements or declarations in block statements *)
+
+and pp_syntax_stat_or_decl ~level fmt (value : value) : unit =
+  match id_of_case_v value with
+  | "variableDeclaration" | "constantDeclaration" ->
+      pp_syntax_decl ~level fmt value
+  | "assignmentOrMethodCallStatement" | "directApplication"
+  | "conditionalStatement" | "emptyStatement" | "blockStatement"
+  | "returnStatement" | "breakStatement" | "continueStatement" | "exitStatement"
+  | "switchStatement" | "forStatement" ->
+      pp_syntax_stmt ~level fmt value
+  | _ ->
+      failwith
+        (Printf.sprintf
+           "@pp_syntax_stat_or_decl: expected variable declaration, constant \
+            declaration, or statement, got %s"
+           (id_of_case_v value))
+
 (* Statements *)
 
 and pp_syntax_stmt ~level fmt (value : value) : unit =
@@ -723,6 +756,27 @@ and pp_syntax_stmt ~level fmt (value : value) : unit =
     | _ -> false
   in
   match flatten_case_v value with
+  | ( "assignmentOrMethodCallStatementWithoutSemicolon",
+      [ []; [ "(" ]; [ ")" ] ],
+      [ func; args ] ) ->
+      F.fprintf fmt "%a(%a)" pp_case_v func (pp_list_v ~level:0 ~sep:Comma) args
+  | ( "assignmentOrMethodCallStatementWithoutSemicolon",
+      [ []; [ "<" ]; [ ">"; "(" ]; [ ")" ] ],
+      [ func; targs; args ] ) ->
+      F.fprintf fmt "%a<%a>(%a)" pp_case_v func
+        (pp_list_v ~level:0 ~sep:Comma)
+        targs
+        (pp_list_v ~level:0 ~sep:Comma)
+        args
+  | ( "assignmentOrMethodCallStatementWithoutSemicolon",
+      [ []; [ assign_op ]; [] ],
+      [ lhs; rhs ] )
+    when is_assign_op assign_op ->
+      F.fprintf fmt "%a %s (%a)" pp_case_v lhs assign_op pp_case_v rhs
+  | "assignmentOrMethodCallStatementWithoutSemicolon", _, _ ->
+      failwith
+        (F.asprintf "@pp_syntax_stmt: ill-formed statement helper:\n%a"
+           pp_case_v value)
   | "assignmentOrMethodCallStatement", [ []; [ ";" ] ], [ stmt' ] ->
       F.fprintf fmt "%a;" pp_case_v stmt'
   | ( "directApplication",
@@ -752,6 +806,11 @@ and pp_syntax_stmt ~level fmt (value : value) : unit =
   | "continueStatement", [ [ "CONTINUE"; ";" ] ], [] ->
       F.fprintf fmt "continue;"
   | "exitStatement", [ [ "EXIT"; ";" ] ], [] -> F.fprintf fmt "exit;"
+  | "switchLabel", [ [ "DEFAULT" ] ], [] -> F.fprintf fmt "default"
+  | "switchCase", [ []; [ ":" ]; [] ], [ label; code ] ->
+      F.fprintf fmt "%a: %a" pp_case_v label (pp_syntax_stmt ~level) code
+  | "switchCase", [ []; [ ":" ] ], [ label ] ->
+      F.fprintf fmt "%a:" pp_case_v label
   | ( "switchStatement",
       [ [ "SWITCH"; "(" ]; [ ")"; "{" ]; [ "}" ] ],
       [ expr; cases ] ) ->
@@ -784,32 +843,6 @@ and pp_syntax_stmt ~level fmt (value : value) : unit =
         (pp_opt_annos ~level:0 ~sep:Space)
         opt_annos_in pp_case_v typ pp_case_v name pp_case_v collection
         (pp_syntax_stmt ~level) body
-  | ( "assignmentOrMethodCallStatementWithoutSemicolon",
-      [ []; [ "(" ]; [ ")" ] ],
-      [ func; args ] ) ->
-      F.fprintf fmt "%a(%a)" pp_case_v func (pp_list_v ~level:0 ~sep:Comma) args
-  | ( "assignmentOrMethodCallStatementWithoutSemicolon",
-      [ []; [ "<" ]; [ ">"; "(" ]; [ ")" ] ],
-      [ func; targs; args ] ) ->
-      F.fprintf fmt "%a<%a>(%a)" pp_case_v func
-        (pp_list_v ~level:0 ~sep:Comma)
-        targs
-        (pp_list_v ~level:0 ~sep:Comma)
-        args
-  | ( "assignmentOrMethodCallStatementWithoutSemicolon",
-      [ []; [ assign_op ]; [] ],
-      [ lhs; rhs ] )
-    when is_assign_op assign_op ->
-      F.fprintf fmt "%a %s (%a)" pp_case_v lhs assign_op pp_case_v rhs
-  | "assignmentOrMethodCallStatementWithoutSemicolon", _, _ ->
-      failwith
-        (F.asprintf "@pp_syntax_stmt: ill-formed statement helper:\n%a"
-           pp_case_v value)
-  | "switchLabel", [ [ "DEFAULT" ] ], [] -> F.fprintf fmt "default"
-  | "switchCase", [ []; [ ":" ]; [] ], [ label; code ] ->
-      F.fprintf fmt "%a: %a" pp_case_v label (pp_syntax_stmt ~level) code
-  | "switchCase", [ []; [ ":" ] ], [ label ] ->
-      F.fprintf fmt "%a:" pp_case_v label
   | "forCollectionExpr", [ []; [ ".." ]; [] ], [ expr_l; expr_r ] ->
       F.fprintf fmt "(%a)..(%a)" pp_case_v expr_l pp_case_v expr_r
   | _ ->
@@ -865,39 +898,6 @@ and pp_syntax_mthd ~level fmt (value : value) : unit =
   | _ ->
       failwith
         (Printf.sprintf "@pp_syntax_method: expected methodPrototype, got %s"
-           (id_of_case_v value))
-
-(* Statements or declarations in block statements *)
-
-and pp_syntax_stat_or_decl ~level fmt (value : value) : unit =
-  match id_of_case_v value with
-  | "variableDeclaration" | "constantDeclaration" ->
-      pp_syntax_decl ~level fmt value
-  | "assignmentOrMethodCallStatement" | "directApplication"
-  | "conditionalStatement" | "emptyStatement" | "blockStatement"
-  | "returnStatement" | "breakStatement" | "continueStatement" | "exitStatement"
-  | "switchStatement" | "forStatement" ->
-      pp_syntax_stmt ~level fmt value
-  | _ ->
-      failwith
-        (Printf.sprintf
-           "@pp_syntax_stat_or_decl: expected variable declaration, constant \
-            declaration, or statement, got %s"
-           (id_of_case_v value))
-
-(* Statements in for init statements *)
-
-and pp_syntax_decl_or_assign_or_call_stmt fmt (value : value) : unit =
-  match id_of_case_v value with
-  | "variableDeclarationWithoutSemicolon" -> pp_case_v fmt value
-  | "assignmentOrMethodCallStatementWithoutSemicolon" ->
-      pp_syntax_stmt ~level:0 fmt value
-  | _ ->
-      failwith
-        (Printf.sprintf
-           "@pp_syntax_decl_or_assign_or_call_stmt: expected variable \
-            declaration, assignment statement, or method call statement, got \
-            %s"
            (id_of_case_v value))
 
 (* Object initializers *)
@@ -1205,12 +1205,6 @@ and pp_syntax_struct_field fmt (value : value) : unit =
 
 and pp_syntax_decl ~level fmt (value : value) : unit =
   match flatten_case_v value with
-  | ( "constantDeclaration",
-      [ []; [ "CONST" ]; []; []; [ ";" ] ],
-      [ opt_annos; type_ref; name; init ] ) ->
-      F.fprintf fmt "%aconst %a %a%a;"
-        (pp_opt_annos ~level ~sep:Nl)
-        opt_annos pp_case_v type_ref pp_case_v name pp_case_v init
   | ( "variableDeclarationWithoutSemicolon",
       [ []; []; []; []; [] ],
       [ opt_annos; type_ref; name; opt_init ] ) ->
@@ -1221,6 +1215,12 @@ and pp_syntax_decl ~level fmt (value : value) : unit =
         opt_init
   | "variableDeclaration", [ []; [ ";" ] ], [ decl ] ->
       F.fprintf fmt "%a;" pp_case_v decl
+  | ( "constantDeclaration",
+      [ []; [ "CONST" ]; []; []; [ ";" ] ],
+      [ opt_annos; type_ref; name; init ] ) ->
+      F.fprintf fmt "%aconst %a %a%a;"
+        (pp_opt_annos ~level ~sep:Nl)
+        opt_annos pp_case_v type_ref pp_case_v name pp_case_v init
   | ( "matchKindDeclaration",
       [ [ "MATCH_KIND"; "{" ]; []; [ "}" ] ],
       [ ids; comma ] ) ->

--- a/p4spec/lib/parsing/pp.ml
+++ b/p4spec/lib/parsing/pp.ml
@@ -1352,7 +1352,7 @@ and pp_syntax_anno fmt (value : value) : unit =
       F.fprintf fmt "@%a" pp_case_v name
   | "annotation", [ [ "@" ]; [ "(" ]; [ ")" ] ], [ name; body ] ->
       F.fprintf fmt "@%a(%a)" pp_case_v name
-        (pp_list_v ~level:0 ~sep:Comma)
+        (pp_list_v ~level:0 ~sep:SpaceSep)
         body
   | "annotation", [ [ "@" ]; [ "[" ]; [ "]" ] ], [ name; body ] ->
       F.fprintf fmt "@%a[%a]" pp_case_v name pp_case_v body
@@ -1412,7 +1412,7 @@ and pp_case_v' fmt (value : value) : unit =
         opt_annos pp_case_v type_ref pp_case_v name
   (* Annotations *)
   | "simpleAnnotation", [ [ "(" ]; [ ")" ] ], [ body ] ->
-      F.fprintf fmt "(%a)" (pp_list_v ~level:0 ~sep:Comma) body
+      F.fprintf fmt "(%a)" (pp_list_v ~level:0 ~sep:SpaceSep) body
   | _ -> pp_default_case_v fmt value
 
 and pp_case_v fmt (value : value) : unit =

--- a/p4spec/lib/parsing/pp_utils.ml
+++ b/p4spec/lib/parsing/pp_utils.ml
@@ -2,11 +2,12 @@ module F = Format
 
 (* Separator *)
 
-type sep = Nl | Comma | CommaNl | Semicolon | SemicolonNl
+type sep = SpaceSep | Nl | Comma | CommaNl | Semicolon | SemicolonNl
 
 let is_nl = function Nl | CommaNl | SemicolonNl -> true | _ -> false
 
 let pp_sep fmt = function
+  | SpaceSep -> F.fprintf fmt " "
   | Nl -> F.fprintf fmt "\n"
   | Comma -> F.fprintf fmt ", "
   | CommaNl -> F.fprintf fmt ",\n"

--- a/p4spec/lib/parsing/pp_utils.ml
+++ b/p4spec/lib/parsing/pp_utils.ml
@@ -36,6 +36,14 @@ let pp_list ?(level = 0) pp_elem ~(sep : sep) fmt l =
       if i < List.length l - 1 then pp_sep fmt sep)
     l
 
+let pp_list_no_start_indent ?(level = 0) pp_elem ~(sep : sep) fmt l =
+  List.iteri
+    (fun i elem ->
+      let startline = if is_nl sep && i <> 0 then indent level else "" in
+      F.fprintf fmt "%s%a" startline pp_elem elem;
+      if i < List.length l - 1 then pp_sep fmt sep)
+    l
+
 let pp_pairs ?(trailing = false) ?(level = 0) pp_k pp_v ~(rel : rel)
     ~(sep : sep) fmt pairs =
   List.iteri

--- a/p4spec/lib/parsing/pp_utils.ml
+++ b/p4spec/lib/parsing/pp_utils.ml
@@ -2,26 +2,17 @@ module F = Format
 
 (* Separator *)
 
-type sep = SpaceSep | Nl | Comma | CommaNl | Semicolon | SemicolonNl
+type sep = Space | Nl | Comma | CommaNl | Semicolon | SemicolonNl
 
 let is_nl = function Nl | CommaNl | SemicolonNl -> true | _ -> false
 
 let pp_sep fmt = function
-  | SpaceSep -> F.fprintf fmt " "
+  | Space -> F.fprintf fmt " "
   | Nl -> F.fprintf fmt "\n"
   | Comma -> F.fprintf fmt ", "
   | CommaNl -> F.fprintf fmt ",\n"
   | Semicolon -> F.fprintf fmt "; "
   | SemicolonNl -> F.fprintf fmt ";\n"
-
-(* Relations *)
-
-type rel = Space | Colon | Eq
-
-let pp_rel fmt = function
-  | Space -> F.fprintf fmt " "
-  | Colon -> F.fprintf fmt ": "
-  | Eq -> F.fprintf fmt " = "
 
 (* Printers *)
 
@@ -44,7 +35,7 @@ let pp_list_no_start_indent ?(level = 0) pp_elem ~(sep : sep) fmt l =
       if i < List.length l - 1 then pp_sep fmt sep)
     l
 
-let pp_pairs ?(trailing = false) ?(level = 0) pp_k pp_v ~(rel : rel)
+(* let pp_pairs ?(trailing = false) ?(level = 0) pp_k pp_v ~(rel : rel)
     ~(sep : sep) fmt pairs =
   List.iteri
     (fun i (k, v) ->
@@ -52,4 +43,4 @@ let pp_pairs ?(trailing = false) ?(level = 0) pp_k pp_v ~(rel : rel)
       F.fprintf fmt "%s%a%a%a" startline pp_k k pp_rel rel pp_v v;
       if i < List.length pairs - 1 then pp_sep fmt sep)
     pairs;
-  if trailing && pairs <> [] then pp_sep fmt sep
+  if trailing && pairs <> [] then pp_sep fmt sep *)

--- a/p4spec/test/parser_p4c_neg.expected
+++ b/p4spec/test/parser_p4c_neg.expected
@@ -18,7 +18,7 @@ Parser success: ../../../../p4c/testdata/p4_16_errors/action-bind3.p4
 
 >>> Running parser test on ../../../../p4c/testdata/p4_16_errors/action-named-default-bmv2.p4
 Error on parser: ../../../../p4c/testdata/p4_16_errors/action-named-default-bmv2.p4
-../../../../p4c/testdata/p4_16_errors/action-named-default-bmv2.p4:56.12-56.19: syntax error at line 1, column 8097
+../../../../p4c/testdata/p4_16_errors/action-named-default-bmv2.p4:56.12-56.19: syntax error at line 1, column 8138
 
 >>> Running parser test on ../../../../p4c/testdata/p4_16_errors/actions-with-duplicate-control-plane-names1.p4
 Parser success: ../../../../p4c/testdata/p4_16_errors/actions-with-duplicate-control-plane-names1.p4
@@ -58,11 +58,11 @@ Parser success: ../../../../p4c/testdata/p4_16_errors/const_e.p4
 
 >>> Running parser test on ../../../../p4c/testdata/p4_16_errors/constructor1_e.p4
 Error on parser: ../../../../p4c/testdata/p4_16_errors/constructor1_e.p4
-../../../../p4c/testdata/p4_16_errors/constructor1_e.p4:18.9-18.10: syntax error at line 1, column 296
+../../../../p4c/testdata/p4_16_errors/constructor1_e.p4:18.9-18.10: syntax error at line 1, column 244
 
 >>> Running parser test on ../../../../p4c/testdata/p4_16_errors/constructor2_e.p4
 Error on parser: ../../../../p4c/testdata/p4_16_errors/constructor2_e.p4
-../../../../p4c/testdata/p4_16_errors/constructor2_e.p4:18.6-18.7: syntax error at line 1, column 293
+../../../../p4c/testdata/p4_16_errors/constructor2_e.p4:18.6-18.7: syntax error at line 1, column 241
 
 >>> Running parser test on ../../../../p4c/testdata/p4_16_errors/constructor3_e.p4
 Parser success: ../../../../p4c/testdata/p4_16_errors/constructor3_e.p4
@@ -72,7 +72,7 @@ Parser success: ../../../../p4c/testdata/p4_16_errors/constructor_e.p4
 
 >>> Running parser test on ../../../../p4c/testdata/p4_16_errors/control-inline.p4
 Error on parser: ../../../../p4c/testdata/p4_16_errors/control-inline.p4
-../../../../p4c/testdata/p4_16_errors/control-inline.p4:34.11-34.12: syntax error at line 1, column 7673
+../../../../p4c/testdata/p4_16_errors/control-inline.p4:34.11-34.12: syntax error at line 1, column 7714
 
 >>> Running parser test on ../../../../p4c/testdata/p4_16_errors/control-verify.p4
 Parser success: ../../../../p4c/testdata/p4_16_errors/control-verify.p4
@@ -133,7 +133,7 @@ Parser success: ../../../../p4c/testdata/p4_16_errors/equality-fail.p4
 
 >>> Running parser test on ../../../../p4c/testdata/p4_16_errors/expression_e.p4
 Error on parser: ../../../../p4c/testdata/p4_16_errors/expression_e.p4
-../../../../p4c/testdata/p4_16_errors/expression_e.p4:21.20-21.21: syntax error at line 1, column 336
+../../../../p4c/testdata/p4_16_errors/expression_e.p4:21.20-21.21: syntax error at line 1, column 284
 
 >>> Running parser test on ../../../../p4c/testdata/p4_16_errors/extern.p4
 Parser success: ../../../../p4c/testdata/p4_16_errors/extern.p4
@@ -173,11 +173,11 @@ Parser success: ../../../../p4c/testdata/p4_16_errors/generic1_e.p4
 
 >>> Running parser test on ../../../../p4c/testdata/p4_16_errors/globalVar_e.p4
 Error on parser: ../../../../p4c/testdata/p4_16_errors/globalVar_e.p4
-../../../../p4c/testdata/p4_16_errors/globalVar_e.p4:16.6-16.7: syntax error at line 1, column 273
+../../../../p4c/testdata/p4_16_errors/globalVar_e.p4:16.6-16.7: syntax error at line 1, column 221
 
 >>> Running parser test on ../../../../p4c/testdata/p4_16_errors/header1_e.p4
 Error on parser: ../../../../p4c/testdata/p4_16_errors/header1_e.p4
-../../../../p4c/testdata/p4_16_errors/header1_e.p4:18.5-18.6: syntax error at line 1, column 278
+../../../../p4c/testdata/p4_16_errors/header1_e.p4:18.5-18.6: syntax error at line 1, column 226
 
 >>> Running parser test on ../../../../p4c/testdata/p4_16_errors/header2_e.p4
 Parser success: ../../../../p4c/testdata/p4_16_errors/header2_e.p4
@@ -211,7 +211,7 @@ Parser success: ../../../../p4c/testdata/p4_16_errors/interface_e.p4
 
 >>> Running parser test on ../../../../p4c/testdata/p4_16_errors/invalid-invalid.p4
 Error on parser: ../../../../p4c/testdata/p4_16_errors/invalid-invalid.p4
-../../../../p4c/testdata/p4_16_errors/invalid-invalid.p4:2.1: syntax error at line 1, column 247
+../../../../p4c/testdata/p4_16_errors/invalid-invalid.p4:2.1: syntax error at line 1, column 195
 
 >>> Running parser test on ../../../../p4c/testdata/p4_16_errors/issue-2123_e.p4
 Parser success: ../../../../p4c/testdata/p4_16_errors/issue-2123_e.p4
@@ -224,7 +224,7 @@ Parser success: ../../../../p4c/testdata/p4_16_errors/issue1059.p4
 
 >>> Running parser test on ../../../../p4c/testdata/p4_16_errors/issue1202.p4
 Error on parser: ../../../../p4c/testdata/p4_16_errors/issue1202.p4
-../../../../p4c/testdata/p4_16_errors/issue1202.p4:1.19-1.22: syntax error at line 1, column 222
+../../../../p4c/testdata/p4_16_errors/issue1202.p4:1.19-1.22: syntax error at line 1, column 170
 
 >>> Running parser test on ../../../../p4c/testdata/p4_16_errors/issue122.p4
 Parser success: ../../../../p4c/testdata/p4_16_errors/issue122.p4
@@ -240,7 +240,7 @@ Parser success: ../../../../p4c/testdata/p4_16_errors/issue1331.p4
 
 >>> Running parser test on ../../../../p4c/testdata/p4_16_errors/issue1336.p4
 Error on parser: ../../../../p4c/testdata/p4_16_errors/issue1336.p4
-../../../../p4c/testdata/p4_16_errors/issue1336.p4:3.15-3.16: syntax error at line 1, column 235
+../../../../p4c/testdata/p4_16_errors/issue1336.p4:3.15-3.16: syntax error at line 1, column 183
 
 >>> Running parser test on ../../../../p4c/testdata/p4_16_errors/issue1542.p4
 Parser success: ../../../../p4c/testdata/p4_16_errors/issue1542.p4
@@ -358,7 +358,7 @@ Parser success: ../../../../p4c/testdata/p4_16_errors/issue2525.p4
 
 >>> Running parser test on ../../../../p4c/testdata/p4_16_errors/issue2544_recursive.p4
 Error on parser: ../../../../p4c/testdata/p4_16_errors/issue2544_recursive.p4
-../../../../p4c/testdata/p4_16_errors/issue2544_recursive.p4:2.12-2.13: syntax error at line 1, column 236
+../../../../p4c/testdata/p4_16_errors/issue2544_recursive.p4:2.12-2.13: syntax error at line 1, column 184
 
 >>> Running parser test on ../../../../p4c/testdata/p4_16_errors/issue2544_self_ref.p4
 Parser success: ../../../../p4c/testdata/p4_16_errors/issue2544_self_ref.p4
@@ -407,7 +407,7 @@ Parser success: ../../../../p4c/testdata/p4_16_errors/issue3197-e.p4
 
 >>> Running parser test on ../../../../p4c/testdata/p4_16_errors/issue3210.p4
 Error on parser: ../../../../p4c/testdata/p4_16_errors/issue3210.p4
-../../../../p4c/testdata/p4_16_errors/issue3210.p4:9.6-9.7: syntax error at line 1, column 290
+../../../../p4c/testdata/p4_16_errors/issue3210.p4:9.6-9.7: syntax error at line 1, column 238
 
 >>> Running parser test on ../../../../p4c/testdata/p4_16_errors/issue3221.p4
 Parser success: ../../../../p4c/testdata/p4_16_errors/issue3221.p4
@@ -423,11 +423,11 @@ Parser success: ../../../../p4c/testdata/p4_16_errors/issue3264.p4
 
 >>> Running parser test on ../../../../p4c/testdata/p4_16_errors/issue3271-1.p4
 Error on parser: ../../../../p4c/testdata/p4_16_errors/issue3271-1.p4
-../../../../p4c/testdata/p4_16_errors/issue3271-1.p4:23.8-23.9: syntax error at line 1, column 393
+../../../../p4c/testdata/p4_16_errors/issue3271-1.p4:23.8-23.9: syntax error at line 1, column 341
 
 >>> Running parser test on ../../../../p4c/testdata/p4_16_errors/issue3271.p4
 Error on parser: ../../../../p4c/testdata/p4_16_errors/issue3271.p4
-../../../../p4c/testdata/p4_16_errors/issue3271.p4:3.8-3.9: syntax error at line 1, column 245
+../../../../p4c/testdata/p4_16_errors/issue3271.p4:3.8-3.9: syntax error at line 1, column 193
 
 >>> Running parser test on ../../../../p4c/testdata/p4_16_errors/issue3273.p4
 Parser success: ../../../../p4c/testdata/p4_16_errors/issue3273.p4
@@ -668,7 +668,7 @@ Parser success: ../../../../p4c/testdata/p4_16_errors/loop2-err.p4
 
 >>> Running parser test on ../../../../p4c/testdata/p4_16_errors/loop3-err.p4
 Error on parser: ../../../../p4c/testdata/p4_16_errors/loop3-err.p4
-../../../../p4c/testdata/p4_16_errors/loop3-err.p4:51.16-51.18: syntax error at line 1, column 7954
+../../../../p4c/testdata/p4_16_errors/loop3-err.p4:51.16-51.18: syntax error at line 1, column 7995
 
 >>> Running parser test on ../../../../p4c/testdata/p4_16_errors/methodArgDontcare.p4
 Parser success: ../../../../p4c/testdata/p4_16_errors/methodArgDontcare.p4
@@ -714,7 +714,7 @@ Parser success: ../../../../p4c/testdata/p4_16_errors/not_bound.p4
 
 >>> Running parser test on ../../../../p4c/testdata/p4_16_errors/p_e.p4
 Error on parser: ../../../../p4c/testdata/p4_16_errors/p_e.p4
-../../../../p4c/testdata/p4_16_errors/p_e.p4:18.1: syntax error at line 1, column 249
+../../../../p4c/testdata/p4_16_errors/p_e.p4:18.1: syntax error at line 1, column 197
 
 >>> Running parser test on ../../../../p4c/testdata/p4_16_errors/package.p4
 Parser success: ../../../../p4c/testdata/p4_16_errors/package.p4
@@ -769,7 +769,7 @@ Parser success: ../../../../p4c/testdata/p4_16_errors/shift-int-non-const.p4
 
 >>> Running parser test on ../../../../p4c/testdata/p4_16_errors/shift_e.p4
 Error on parser: ../../../../p4c/testdata/p4_16_errors/shift_e.p4
-../../../../p4c/testdata/p4_16_errors/shift_e.p4:20.25-20.26: syntax error at line 1, column 332
+../../../../p4c/testdata/p4_16_errors/shift_e.p4:20.25-20.26: syntax error at line 1, column 280
 
 >>> Running parser test on ../../../../p4c/testdata/p4_16_errors/signed.p4
 Parser success: ../../../../p4c/testdata/p4_16_errors/signed.p4
@@ -830,11 +830,11 @@ Parser success: ../../../../p4c/testdata/p4_16_errors/structure-valued-expr-errs
 
 >>> Running parser test on ../../../../p4c/testdata/p4_16_errors/structure-valued-expr-errs-2.p4
 Error on parser: ../../../../p4c/testdata/p4_16_errors/structure-valued-expr-errs-2.p4
-../../../../p4c/testdata/p4_16_errors/structure-valued-expr-errs-2.p4:106.28-106.29: syntax error at line 1, column 8591
+../../../../p4c/testdata/p4_16_errors/structure-valued-expr-errs-2.p4:106.28-106.29: syntax error at line 1, column 8632
 
 >>> Running parser test on ../../../../p4c/testdata/p4_16_errors/structured-annotation-e.p4
 Error on parser: ../../../../p4c/testdata/p4_16_errors/structured-annotation-e.p4
-../../../../p4c/testdata/p4_16_errors/structured-annotation-e.p4:1.23-1.24: syntax error at line 1, column 254
+../../../../p4c/testdata/p4_16_errors/structured-annotation-e.p4:1.23-1.24: syntax error at line 1, column 202
 
 >>> Running parser test on ../../../../p4c/testdata/p4_16_errors/structured-annotation-e1.p4
 Parser success: ../../../../p4c/testdata/p4_16_errors/structured-annotation-e1.p4
@@ -865,7 +865,7 @@ Parser success: ../../../../p4c/testdata/p4_16_errors/table-entries-optional-2-b
 
 >>> Running parser test on ../../../../p4c/testdata/p4_16_errors/table-entries-outside-table.p4
 Error on parser: ../../../../p4c/testdata/p4_16_errors/table-entries-outside-table.p4
-../../../../p4c/testdata/p4_16_errors/table-entries-outside-table.p4:68.11-68.18: syntax error at line 1, column 8421
+../../../../p4c/testdata/p4_16_errors/table-entries-outside-table.p4:68.11-68.18: syntax error at line 1, column 8462
 
 >>> Running parser test on ../../../../p4c/testdata/p4_16_errors/table-entries-range.p4
 Parser success: ../../../../p4c/testdata/p4_16_errors/table-entries-range.p4
@@ -878,7 +878,7 @@ Parser success: ../../../../p4c/testdata/p4_16_errors/template_e.p4
 
 >>> Running parser test on ../../../../p4c/testdata/p4_16_errors/tuple-left.p4
 Error on parser: ../../../../p4c/testdata/p4_16_errors/tuple-left.p4
-../../../../p4c/testdata/p4_16_errors/tuple-left.p4:21.12-21.13: syntax error at line 1, column 332
+../../../../p4c/testdata/p4_16_errors/tuple-left.p4:21.12-21.13: syntax error at line 1, column 280
 
 >>> Running parser test on ../../../../p4c/testdata/p4_16_errors/tuple-newtype.p4
 Parser success: ../../../../p4c/testdata/p4_16_errors/tuple-newtype.p4
@@ -894,11 +894,11 @@ Parser success: ../../../../p4c/testdata/p4_16_errors/type-field.p4
 
 >>> Running parser test on ../../../../p4c/testdata/p4_16_errors/type-in-expr-lex0.p4
 Error on parser: ../../../../p4c/testdata/p4_16_errors/type-in-expr-lex0.p4
-../../../../p4c/testdata/p4_16_errors/type-in-expr-lex0.p4:8.26-8.27: syntax error at line 1, column 1151
+../../../../p4c/testdata/p4_16_errors/type-in-expr-lex0.p4:8.26-8.27: syntax error at line 1, column 1099
 
 >>> Running parser test on ../../../../p4c/testdata/p4_16_errors/type-in-expr-lex1.p4
 Error on parser: ../../../../p4c/testdata/p4_16_errors/type-in-expr-lex1.p4
-../../../../p4c/testdata/p4_16_errors/type-in-expr-lex1.p4:8.22-8.23: syntax error at line 1, column 1180
+../../../../p4c/testdata/p4_16_errors/type-in-expr-lex1.p4:8.22-8.23: syntax error at line 1, column 1128
 
 >>> Running parser test on ../../../../p4c/testdata/p4_16_errors/type-in-expr.p4
 Parser success: ../../../../p4c/testdata/p4_16_errors/type-in-expr.p4
@@ -917,19 +917,19 @@ Parser success: ../../../../p4c/testdata/p4_16_errors/typedef-and-type-definitio
 
 >>> Running parser test on ../../../../p4c/testdata/p4_16_errors/underscore1_e.p4
 Error on parser: ../../../../p4c/testdata/p4_16_errors/underscore1_e.p4
-../../../../p4c/testdata/p4_16_errors/underscore1_e.p4:17.9-17.10: syntax error at line 1, column 293
+../../../../p4c/testdata/p4_16_errors/underscore1_e.p4:17.9-17.10: syntax error at line 1, column 241
 
 >>> Running parser test on ../../../../p4c/testdata/p4_16_errors/underscore2_e.p4
 Error on parser: ../../../../p4c/testdata/p4_16_errors/underscore2_e.p4
-../../../../p4c/testdata/p4_16_errors/underscore2_e.p4:19.13-19.14: syntax error at line 1, column 312
+../../../../p4c/testdata/p4_16_errors/underscore2_e.p4:19.13-19.14: syntax error at line 1, column 260
 
 >>> Running parser test on ../../../../p4c/testdata/p4_16_errors/underscore3_e.p4
 Error on parser: ../../../../p4c/testdata/p4_16_errors/underscore3_e.p4
-../../../../p4c/testdata/p4_16_errors/underscore3_e.p4:16.11-16.12: syntax error at line 1, column 284
+../../../../p4c/testdata/p4_16_errors/underscore3_e.p4:16.11-16.12: syntax error at line 1, column 232
 
 >>> Running parser test on ../../../../p4c/testdata/p4_16_errors/underscore_e.p4
 Error on parser: ../../../../p4c/testdata/p4_16_errors/underscore_e.p4
-../../../../p4c/testdata/p4_16_errors/underscore_e.p4:16.13-16.14: syntax error at line 1, column 283
+../../../../p4c/testdata/p4_16_errors/underscore_e.p4:16.13-16.14: syntax error at line 1, column 231
 
 >>> Running parser test on ../../../../p4c/testdata/p4_16_errors/virtual1.p4
 Parser success: ../../../../p4c/testdata/p4_16_errors/virtual1.p4

--- a/p4spec/test/parser_p4c_neg.expected
+++ b/p4spec/test/parser_p4c_neg.expected
@@ -18,7 +18,7 @@ Parser success: ../../../../p4c/testdata/p4_16_errors/action-bind3.p4
 
 >>> Running parser test on ../../../../p4c/testdata/p4_16_errors/action-named-default-bmv2.p4
 Error on parser: ../../../../p4c/testdata/p4_16_errors/action-named-default-bmv2.p4
-../../../../p4c/testdata/p4_16_errors/action-named-default-bmv2.p4:56.12-56.19: syntax error at line 1, column 8138
+../../../../p4c/testdata/p4_16_errors/action-named-default-bmv2.p4:56.12-56.19: syntax error
 
 >>> Running parser test on ../../../../p4c/testdata/p4_16_errors/actions-with-duplicate-control-plane-names1.p4
 Parser success: ../../../../p4c/testdata/p4_16_errors/actions-with-duplicate-control-plane-names1.p4
@@ -58,11 +58,11 @@ Parser success: ../../../../p4c/testdata/p4_16_errors/const_e.p4
 
 >>> Running parser test on ../../../../p4c/testdata/p4_16_errors/constructor1_e.p4
 Error on parser: ../../../../p4c/testdata/p4_16_errors/constructor1_e.p4
-../../../../p4c/testdata/p4_16_errors/constructor1_e.p4:18.9-18.10: syntax error at line 1, column 244
+../../../../p4c/testdata/p4_16_errors/constructor1_e.p4:18.9-18.10: syntax error
 
 >>> Running parser test on ../../../../p4c/testdata/p4_16_errors/constructor2_e.p4
 Error on parser: ../../../../p4c/testdata/p4_16_errors/constructor2_e.p4
-../../../../p4c/testdata/p4_16_errors/constructor2_e.p4:18.6-18.7: syntax error at line 1, column 241
+../../../../p4c/testdata/p4_16_errors/constructor2_e.p4:18.6-18.7: syntax error
 
 >>> Running parser test on ../../../../p4c/testdata/p4_16_errors/constructor3_e.p4
 Parser success: ../../../../p4c/testdata/p4_16_errors/constructor3_e.p4
@@ -72,7 +72,7 @@ Parser success: ../../../../p4c/testdata/p4_16_errors/constructor_e.p4
 
 >>> Running parser test on ../../../../p4c/testdata/p4_16_errors/control-inline.p4
 Error on parser: ../../../../p4c/testdata/p4_16_errors/control-inline.p4
-../../../../p4c/testdata/p4_16_errors/control-inline.p4:34.11-34.12: syntax error at line 1, column 7714
+../../../../p4c/testdata/p4_16_errors/control-inline.p4:34.11-34.12: syntax error
 
 >>> Running parser test on ../../../../p4c/testdata/p4_16_errors/control-verify.p4
 Parser success: ../../../../p4c/testdata/p4_16_errors/control-verify.p4
@@ -133,7 +133,7 @@ Parser success: ../../../../p4c/testdata/p4_16_errors/equality-fail.p4
 
 >>> Running parser test on ../../../../p4c/testdata/p4_16_errors/expression_e.p4
 Error on parser: ../../../../p4c/testdata/p4_16_errors/expression_e.p4
-../../../../p4c/testdata/p4_16_errors/expression_e.p4:21.20-21.21: syntax error at line 1, column 284
+../../../../p4c/testdata/p4_16_errors/expression_e.p4:21.20-21.21: syntax error
 
 >>> Running parser test on ../../../../p4c/testdata/p4_16_errors/extern.p4
 Parser success: ../../../../p4c/testdata/p4_16_errors/extern.p4
@@ -173,11 +173,11 @@ Parser success: ../../../../p4c/testdata/p4_16_errors/generic1_e.p4
 
 >>> Running parser test on ../../../../p4c/testdata/p4_16_errors/globalVar_e.p4
 Error on parser: ../../../../p4c/testdata/p4_16_errors/globalVar_e.p4
-../../../../p4c/testdata/p4_16_errors/globalVar_e.p4:16.6-16.7: syntax error at line 1, column 221
+../../../../p4c/testdata/p4_16_errors/globalVar_e.p4:16.6-16.7: syntax error
 
 >>> Running parser test on ../../../../p4c/testdata/p4_16_errors/header1_e.p4
 Error on parser: ../../../../p4c/testdata/p4_16_errors/header1_e.p4
-../../../../p4c/testdata/p4_16_errors/header1_e.p4:18.5-18.6: syntax error at line 1, column 226
+../../../../p4c/testdata/p4_16_errors/header1_e.p4:18.5-18.6: syntax error
 
 >>> Running parser test on ../../../../p4c/testdata/p4_16_errors/header2_e.p4
 Parser success: ../../../../p4c/testdata/p4_16_errors/header2_e.p4
@@ -211,7 +211,7 @@ Parser success: ../../../../p4c/testdata/p4_16_errors/interface_e.p4
 
 >>> Running parser test on ../../../../p4c/testdata/p4_16_errors/invalid-invalid.p4
 Error on parser: ../../../../p4c/testdata/p4_16_errors/invalid-invalid.p4
-../../../../p4c/testdata/p4_16_errors/invalid-invalid.p4:2.1: syntax error at line 1, column 195
+../../../../p4c/testdata/p4_16_errors/invalid-invalid.p4:2.1: syntax error
 
 >>> Running parser test on ../../../../p4c/testdata/p4_16_errors/issue-2123_e.p4
 Parser success: ../../../../p4c/testdata/p4_16_errors/issue-2123_e.p4
@@ -224,7 +224,7 @@ Parser success: ../../../../p4c/testdata/p4_16_errors/issue1059.p4
 
 >>> Running parser test on ../../../../p4c/testdata/p4_16_errors/issue1202.p4
 Error on parser: ../../../../p4c/testdata/p4_16_errors/issue1202.p4
-../../../../p4c/testdata/p4_16_errors/issue1202.p4:1.19-1.22: syntax error at line 1, column 170
+../../../../p4c/testdata/p4_16_errors/issue1202.p4:1.19-1.22: syntax error
 
 >>> Running parser test on ../../../../p4c/testdata/p4_16_errors/issue122.p4
 Parser success: ../../../../p4c/testdata/p4_16_errors/issue122.p4
@@ -240,7 +240,7 @@ Parser success: ../../../../p4c/testdata/p4_16_errors/issue1331.p4
 
 >>> Running parser test on ../../../../p4c/testdata/p4_16_errors/issue1336.p4
 Error on parser: ../../../../p4c/testdata/p4_16_errors/issue1336.p4
-../../../../p4c/testdata/p4_16_errors/issue1336.p4:3.15-3.16: syntax error at line 1, column 183
+../../../../p4c/testdata/p4_16_errors/issue1336.p4:3.15-3.16: syntax error
 
 >>> Running parser test on ../../../../p4c/testdata/p4_16_errors/issue1542.p4
 Parser success: ../../../../p4c/testdata/p4_16_errors/issue1542.p4
@@ -358,7 +358,7 @@ Parser success: ../../../../p4c/testdata/p4_16_errors/issue2525.p4
 
 >>> Running parser test on ../../../../p4c/testdata/p4_16_errors/issue2544_recursive.p4
 Error on parser: ../../../../p4c/testdata/p4_16_errors/issue2544_recursive.p4
-../../../../p4c/testdata/p4_16_errors/issue2544_recursive.p4:2.12-2.13: syntax error at line 1, column 184
+../../../../p4c/testdata/p4_16_errors/issue2544_recursive.p4:2.12-2.13: syntax error
 
 >>> Running parser test on ../../../../p4c/testdata/p4_16_errors/issue2544_self_ref.p4
 Parser success: ../../../../p4c/testdata/p4_16_errors/issue2544_self_ref.p4
@@ -407,7 +407,7 @@ Parser success: ../../../../p4c/testdata/p4_16_errors/issue3197-e.p4
 
 >>> Running parser test on ../../../../p4c/testdata/p4_16_errors/issue3210.p4
 Error on parser: ../../../../p4c/testdata/p4_16_errors/issue3210.p4
-../../../../p4c/testdata/p4_16_errors/issue3210.p4:9.6-9.7: syntax error at line 1, column 238
+../../../../p4c/testdata/p4_16_errors/issue3210.p4:9.6-9.7: syntax error
 
 >>> Running parser test on ../../../../p4c/testdata/p4_16_errors/issue3221.p4
 Parser success: ../../../../p4c/testdata/p4_16_errors/issue3221.p4
@@ -423,11 +423,11 @@ Parser success: ../../../../p4c/testdata/p4_16_errors/issue3264.p4
 
 >>> Running parser test on ../../../../p4c/testdata/p4_16_errors/issue3271-1.p4
 Error on parser: ../../../../p4c/testdata/p4_16_errors/issue3271-1.p4
-../../../../p4c/testdata/p4_16_errors/issue3271-1.p4:23.8-23.9: syntax error at line 1, column 341
+../../../../p4c/testdata/p4_16_errors/issue3271-1.p4:23.8-23.9: syntax error
 
 >>> Running parser test on ../../../../p4c/testdata/p4_16_errors/issue3271.p4
 Error on parser: ../../../../p4c/testdata/p4_16_errors/issue3271.p4
-../../../../p4c/testdata/p4_16_errors/issue3271.p4:3.8-3.9: syntax error at line 1, column 193
+../../../../p4c/testdata/p4_16_errors/issue3271.p4:3.8-3.9: syntax error
 
 >>> Running parser test on ../../../../p4c/testdata/p4_16_errors/issue3273.p4
 Parser success: ../../../../p4c/testdata/p4_16_errors/issue3273.p4
@@ -668,7 +668,7 @@ Parser success: ../../../../p4c/testdata/p4_16_errors/loop2-err.p4
 
 >>> Running parser test on ../../../../p4c/testdata/p4_16_errors/loop3-err.p4
 Error on parser: ../../../../p4c/testdata/p4_16_errors/loop3-err.p4
-../../../../p4c/testdata/p4_16_errors/loop3-err.p4:51.16-51.18: syntax error at line 1, column 7995
+../../../../p4c/testdata/p4_16_errors/loop3-err.p4:51.16-51.18: syntax error
 
 >>> Running parser test on ../../../../p4c/testdata/p4_16_errors/methodArgDontcare.p4
 Parser success: ../../../../p4c/testdata/p4_16_errors/methodArgDontcare.p4
@@ -714,7 +714,7 @@ Parser success: ../../../../p4c/testdata/p4_16_errors/not_bound.p4
 
 >>> Running parser test on ../../../../p4c/testdata/p4_16_errors/p_e.p4
 Error on parser: ../../../../p4c/testdata/p4_16_errors/p_e.p4
-../../../../p4c/testdata/p4_16_errors/p_e.p4:18.1: syntax error at line 1, column 197
+../../../../p4c/testdata/p4_16_errors/p_e.p4:18.1: syntax error
 
 >>> Running parser test on ../../../../p4c/testdata/p4_16_errors/package.p4
 Parser success: ../../../../p4c/testdata/p4_16_errors/package.p4
@@ -769,7 +769,7 @@ Parser success: ../../../../p4c/testdata/p4_16_errors/shift-int-non-const.p4
 
 >>> Running parser test on ../../../../p4c/testdata/p4_16_errors/shift_e.p4
 Error on parser: ../../../../p4c/testdata/p4_16_errors/shift_e.p4
-../../../../p4c/testdata/p4_16_errors/shift_e.p4:20.25-20.26: syntax error at line 1, column 280
+../../../../p4c/testdata/p4_16_errors/shift_e.p4:20.25-20.26: syntax error
 
 >>> Running parser test on ../../../../p4c/testdata/p4_16_errors/signed.p4
 Parser success: ../../../../p4c/testdata/p4_16_errors/signed.p4
@@ -830,11 +830,11 @@ Parser success: ../../../../p4c/testdata/p4_16_errors/structure-valued-expr-errs
 
 >>> Running parser test on ../../../../p4c/testdata/p4_16_errors/structure-valued-expr-errs-2.p4
 Error on parser: ../../../../p4c/testdata/p4_16_errors/structure-valued-expr-errs-2.p4
-../../../../p4c/testdata/p4_16_errors/structure-valued-expr-errs-2.p4:106.28-106.29: syntax error at line 1, column 8632
+../../../../p4c/testdata/p4_16_errors/structure-valued-expr-errs-2.p4:106.28-106.29: syntax error
 
 >>> Running parser test on ../../../../p4c/testdata/p4_16_errors/structured-annotation-e.p4
 Error on parser: ../../../../p4c/testdata/p4_16_errors/structured-annotation-e.p4
-../../../../p4c/testdata/p4_16_errors/structured-annotation-e.p4:1.23-1.24: syntax error at line 1, column 202
+../../../../p4c/testdata/p4_16_errors/structured-annotation-e.p4:1.23-1.24: syntax error
 
 >>> Running parser test on ../../../../p4c/testdata/p4_16_errors/structured-annotation-e1.p4
 Parser success: ../../../../p4c/testdata/p4_16_errors/structured-annotation-e1.p4
@@ -865,7 +865,7 @@ Parser success: ../../../../p4c/testdata/p4_16_errors/table-entries-optional-2-b
 
 >>> Running parser test on ../../../../p4c/testdata/p4_16_errors/table-entries-outside-table.p4
 Error on parser: ../../../../p4c/testdata/p4_16_errors/table-entries-outside-table.p4
-../../../../p4c/testdata/p4_16_errors/table-entries-outside-table.p4:68.11-68.18: syntax error at line 1, column 8462
+../../../../p4c/testdata/p4_16_errors/table-entries-outside-table.p4:68.11-68.18: syntax error
 
 >>> Running parser test on ../../../../p4c/testdata/p4_16_errors/table-entries-range.p4
 Parser success: ../../../../p4c/testdata/p4_16_errors/table-entries-range.p4
@@ -878,7 +878,7 @@ Parser success: ../../../../p4c/testdata/p4_16_errors/template_e.p4
 
 >>> Running parser test on ../../../../p4c/testdata/p4_16_errors/tuple-left.p4
 Error on parser: ../../../../p4c/testdata/p4_16_errors/tuple-left.p4
-../../../../p4c/testdata/p4_16_errors/tuple-left.p4:21.12-21.13: syntax error at line 1, column 280
+../../../../p4c/testdata/p4_16_errors/tuple-left.p4:21.12-21.13: syntax error
 
 >>> Running parser test on ../../../../p4c/testdata/p4_16_errors/tuple-newtype.p4
 Parser success: ../../../../p4c/testdata/p4_16_errors/tuple-newtype.p4
@@ -894,11 +894,11 @@ Parser success: ../../../../p4c/testdata/p4_16_errors/type-field.p4
 
 >>> Running parser test on ../../../../p4c/testdata/p4_16_errors/type-in-expr-lex0.p4
 Error on parser: ../../../../p4c/testdata/p4_16_errors/type-in-expr-lex0.p4
-../../../../p4c/testdata/p4_16_errors/type-in-expr-lex0.p4:8.26-8.27: syntax error at line 1, column 1099
+../../../../p4c/testdata/p4_16_errors/type-in-expr-lex0.p4:8.26-8.27: syntax error
 
 >>> Running parser test on ../../../../p4c/testdata/p4_16_errors/type-in-expr-lex1.p4
 Error on parser: ../../../../p4c/testdata/p4_16_errors/type-in-expr-lex1.p4
-../../../../p4c/testdata/p4_16_errors/type-in-expr-lex1.p4:8.22-8.23: syntax error at line 1, column 1128
+../../../../p4c/testdata/p4_16_errors/type-in-expr-lex1.p4:8.22-8.23: syntax error
 
 >>> Running parser test on ../../../../p4c/testdata/p4_16_errors/type-in-expr.p4
 Parser success: ../../../../p4c/testdata/p4_16_errors/type-in-expr.p4
@@ -917,19 +917,19 @@ Parser success: ../../../../p4c/testdata/p4_16_errors/typedef-and-type-definitio
 
 >>> Running parser test on ../../../../p4c/testdata/p4_16_errors/underscore1_e.p4
 Error on parser: ../../../../p4c/testdata/p4_16_errors/underscore1_e.p4
-../../../../p4c/testdata/p4_16_errors/underscore1_e.p4:17.9-17.10: syntax error at line 1, column 241
+../../../../p4c/testdata/p4_16_errors/underscore1_e.p4:17.9-17.10: syntax error
 
 >>> Running parser test on ../../../../p4c/testdata/p4_16_errors/underscore2_e.p4
 Error on parser: ../../../../p4c/testdata/p4_16_errors/underscore2_e.p4
-../../../../p4c/testdata/p4_16_errors/underscore2_e.p4:19.13-19.14: syntax error at line 1, column 260
+../../../../p4c/testdata/p4_16_errors/underscore2_e.p4:19.13-19.14: syntax error
 
 >>> Running parser test on ../../../../p4c/testdata/p4_16_errors/underscore3_e.p4
 Error on parser: ../../../../p4c/testdata/p4_16_errors/underscore3_e.p4
-../../../../p4c/testdata/p4_16_errors/underscore3_e.p4:16.11-16.12: syntax error at line 1, column 232
+../../../../p4c/testdata/p4_16_errors/underscore3_e.p4:16.11-16.12: syntax error
 
 >>> Running parser test on ../../../../p4c/testdata/p4_16_errors/underscore_e.p4
 Error on parser: ../../../../p4c/testdata/p4_16_errors/underscore_e.p4
-../../../../p4c/testdata/p4_16_errors/underscore_e.p4:16.13-16.14: syntax error at line 1, column 231
+../../../../p4c/testdata/p4_16_errors/underscore_e.p4:16.13-16.14: syntax error
 
 >>> Running parser test on ../../../../p4c/testdata/p4_16_errors/virtual1.p4
 Parser success: ../../../../p4c/testdata/p4_16_errors/virtual1.p4

--- a/p4spec/test/parser_p4c_pos.expected
+++ b/p4spec/test/parser_p4c_pos.expected
@@ -516,7 +516,203 @@ Parser success: ../../../../p4c/testdata/p4_16_samples/forloop6.p4
 Parser success: ../../../../p4c/testdata/p4_16_samples/forloop7.p4
 
 >>> Running parser test on ../../../../p4c/testdata/p4_16_samples/free-form-annotation.p4
-Parser success: ../../../../p4c/testdata/p4_16_samples/free-form-annotation.p4
+Error on parser: roundtrip fail in ../../../../p4c/testdata/p4_16_samples/free-form-annotation.p4
+Parsed file:
+error {
+  NoError,
+  PacketTooShort,
+  NoMatch,
+  StackOutOfBounds,
+  HeaderTooShort,
+  ParserTimeout,
+  ParserInvalidArgument
+}
+extern packet_in {
+  void extract<T>(out T hdr);
+  void extract<T>(out T variableSizeHeader, in bit<32> variableFieldSizeInBits);
+  T lookahead<T>();
+  void advance(in bit<32> sizeInBits);
+  bit<32> length();
+}
+extern packet_out {
+  void emit<T>(in T hdr);
+}
+extern void verify(in bool check, in error toSignal);
+@noWarn("unused")
+action NoAction() {
+
+}
+match_kind {
+  exact,
+  ternary,
+  lpm
+}
+extern bool static_assert(bool check, string message);
+extern bool static_assert(bool check);
+match_kind {
+  range,
+  optional,
+  selector
+}
+const bit<32> __v1model_version = (20180101);
+@metadata
+@name("standard_metadata")
+struct standard_metadata_t {
+  bit<9> ingress_port;
+  bit<9> egress_spec;
+  bit<9> egress_port;
+  bit<32> instance_type;
+  bit<32> packet_length;
+  @alias("queueing_metadata.enq_timestamp") bit<32> enq_timestamp;
+  @alias("queueing_metadata.enq_qdepth") bit<19> enq_qdepth;
+  @alias("queueing_metadata.deq_timedelta") bit<32> deq_timedelta;
+  @alias("queueing_metadata.deq_qdepth") bit<19> deq_qdepth;
+  @alias("intrinsic_metadata.ingress_global_timestamp") bit<48> ingress_global_timestamp;
+  @alias("intrinsic_metadata.egress_global_timestamp") bit<48> egress_global_timestamp;
+  @alias("intrinsic_metadata.mcast_grp") bit<16> mcast_grp;
+  @alias("intrinsic_metadata.egress_rid") bit<16> egress_rid;
+  bit<1> checksum_error;
+  error parser_error;
+  @alias("intrinsic_metadata.priority") bit<3> priority;
+}
+enum CounterType {
+  packets,
+  bytes,
+  packets_and_bytes
+}
+enum MeterType {
+  packets,
+  bytes
+}
+extern counter {
+  counter(bit<32> size, CounterType type);
+  void count(in bit<32> index);
+}
+extern direct_counter {
+  direct_counter(CounterType type);
+  void count();
+}
+extern meter {
+  meter(bit<32> size, MeterType type);
+  void execute_meter<T>(in bit<32> index, out T result);
+}
+extern direct_meter<T> {
+  direct_meter(MeterType type);
+  void read(out T result);
+}
+extern register<T> {
+  register(bit<32> size);
+  @noSideEffects
+  void read(out T result, in bit<32> index);
+  void write(in bit<32> index, in T value);
+}
+extern action_profile {
+  action_profile(bit<32> size);
+}
+extern void random<T>(out T result, in T lo, in T hi);
+extern void digest<T>(in bit<32> receiver, in T data);
+enum HashAlgorithm {
+  crc32,
+  crc32_custom,
+  crc16,
+  crc16_custom,
+  random,
+  identity,
+  csum16,
+  xor16
+}
+@deprecated("Please use mark_to_drop(standard_metadata) instead.")
+extern void mark_to_drop();
+@pure
+extern void mark_to_drop(inout standard_metadata_t standard_metadata);
+@pure
+extern void hash<O, T, D, M>(out O result, in HashAlgorithm algo, in T base, in D data, in M max);
+extern action_selector {
+  action_selector(HashAlgorithm algorithm, bit<32> size, bit<32> outputWidth);
+}
+enum CloneType {
+  I2E,
+  E2E
+}
+@deprecated("Please use verify_checksum/update_checksum instead.")
+extern Checksum16 {
+  Checksum16();
+  bit<16> get<D>(in D data);
+}
+extern void verify_checksum<T, O>(in bool condition, in T data, in O checksum, HashAlgorithm algo);
+@pure
+extern void update_checksum<T, O>(in bool condition, in T data, inout O checksum, HashAlgorithm algo);
+extern void verify_checksum_with_payload<T, O>(in bool condition, in T data, in O checksum, HashAlgorithm algo);
+@noSideEffects
+extern void update_checksum_with_payload<T, O>(in bool condition, in T data, inout O checksum, HashAlgorithm algo);
+extern void clone(in CloneType type, in bit<32> session);
+@deprecated("Please use 'resubmit_preserving_field_list' instead")
+extern void resubmit<T>(in T data);
+extern void resubmit_preserving_field_list(bit<8> index);
+@deprecated("Please use 'recirculate_preserving_field_list' instead")
+extern void recirculate<T>(in T data);
+extern void recirculate_preserving_field_list(bit<8> index);
+@deprecated("Please use 'clone_preserving_field_list' instead")
+extern void clone3<T>(in CloneType type, in bit<32> session, in T data);
+extern void clone_preserving_field_list(in CloneType type, in bit<32> session, bit<8> index);
+extern void truncate(in bit<32> length);
+extern void assert(in bool check);
+extern void assume(in bool check);
+extern void log_msg(string msg);
+extern void log_msg<T>(string msg, in T data);
+parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_metadata_t standard_metadata);
+control VerifyChecksum<H, M>(inout H hdr, inout M meta);
+@pipeline
+control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+@pipeline
+control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta);
+@deparser
+control Deparser<H>(packet_out b, in H hdr);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
+@scrabble(- What do you get if you multiply six by nine ? - Six by nine . Forty two . - That unexpected_token s it . That unexpected_token s all there is . - I always thought there was something fundamentally wrong with the universe . 3735928559)
+header hdr {
+  bit<112> field;
+}
+struct Header_t {
+  hdr h;
+}
+struct Meta_t {
+
+}
+parser p(packet_in b, out Header_t h, inout Meta_t m, inout standard_metadata_t sm) {
+
+  state start {
+
+    transition accept;
+  }
+}
+control c(inout Header_t h, inout Meta_t m) {
+
+  apply {
+
+  }
+}
+control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t standard_meta) {
+
+  apply {
+
+  }
+}
+control egress(inout Header_t h, inout Meta_t m, inout standard_metadata_t sm) {
+
+  apply {
+
+  }
+}
+control deparser(packet_out b, in Header_t h) {
+
+  apply {
+
+  }
+}
+V1Switch(p(), c(), ingress(), egress(), c(), deparser()) main;
+
 
 >>> Running parser test on ../../../../p4c/testdata/p4_16_samples/function.p4
 Parser success: ../../../../p4c/testdata/p4_16_samples/function.p4
@@ -2469,7 +2665,7 @@ Parser success: ../../../../p4c/testdata/p4_16_samples/next-def-use.p4
 Parser success: ../../../../p4c/testdata/p4_16_samples/noMatch.p4
 
 >>> Running parser test on ../../../../p4c/testdata/p4_16_samples/nonstandard_table_names-bmv2.p4
-Parser success: ../../../../p4c/testdata/p4_16_samples/nonstandard_table_names-bmv2.p4
+Error on parser: unknown error in ../../../../p4c/testdata/p4_16_samples/nonstandard_table_names-bmv2.p4
 
 >>> Running parser test on ../../../../p4c/testdata/p4_16_samples/octal.p4
 Parser success: ../../../../p4c/testdata/p4_16_samples/octal.p4
@@ -2850,7 +3046,7 @@ Parser success: ../../../../p4c/testdata/p4_16_samples/pragma-deprecated.p4
 Parser success: ../../../../p4c/testdata/p4_16_samples/pragma-pkginfo.p4
 
 >>> Running parser test on ../../../../p4c/testdata/p4_16_samples/pragma-string.p4
-Parser success: ../../../../p4c/testdata/p4_16_samples/pragma-string.p4
+Error on parser: unknown error in ../../../../p4c/testdata/p4_16_samples/pragma-string.p4
 
 >>> Running parser test on ../../../../p4c/testdata/p4_16_samples/pragmas.p4
 Parser success: ../../../../p4c/testdata/p4_16_samples/pragmas.p4
@@ -3576,7 +3772,7 @@ Parser success: ../../../../p4c/testdata/p4_16_samples/strength6.p4
 Parser success: ../../../../p4c/testdata/p4_16_samples/string.p4
 
 >>> Running parser test on ../../../../p4c/testdata/p4_16_samples/string_anno.p4
-Parser success: ../../../../p4c/testdata/p4_16_samples/string_anno.p4
+Error on parser: unknown error in ../../../../p4c/testdata/p4_16_samples/string_anno.p4
 
 >>> Running parser test on ../../../../p4c/testdata/p4_16_samples/struct.p4
 Parser success: ../../../../p4c/testdata/p4_16_samples/struct.p4
@@ -3836,4 +4032,4 @@ Parser success: ../../../../p4c/testdata/p4_16_samples/xdp_vlan_push_pop_ebpf-ke
 >>> Running parser test on ../../../../p4c/testdata/p4_16_samples/xor_test.p4
 Parser success: ../../../../p4c/testdata/p4_16_samples/xor_test.p4
 
-Running parser: [EXCLUDE] 0/1278 (0.00%) [PASS] 1277/1278 (99.92%) [FAIL] 1/1278 (0.08%)
+Running parser: [EXCLUDE] 0/1278 (0.00%) [PASS] 1273/1278 (99.61%) [FAIL] 5/1278 (0.39%)

--- a/p4spec/test/parser_p4c_pos.expected
+++ b/p4spec/test/parser_p4c_pos.expected
@@ -507,7 +507,7 @@ Parser success: ../../../../p4c/testdata/p4_16_samples/forloop5.p4
 
 >>> Running parser test on ../../../../p4c/testdata/p4_16_samples/forloop5a.p4
 Error on parser: ../../../../p4c/testdata/p4_16_samples/forloop5a.p4
-../../../../p4c/testdata/p4_16_samples/forloop5a.p4:20.52-20.53: syntax error at line 1, column 1412
+../../../../p4c/testdata/p4_16_samples/forloop5a.p4:20.52-20.53: syntax error at line 1, column 1360
 
 >>> Running parser test on ../../../../p4c/testdata/p4_16_samples/forloop6.p4
 Parser success: ../../../../p4c/testdata/p4_16_samples/forloop6.p4

--- a/p4spec/test/parser_p4c_pos.expected
+++ b/p4spec/test/parser_p4c_pos.expected
@@ -507,7 +507,7 @@ Parser success: ../../../../p4c/testdata/p4_16_samples/forloop5.p4
 
 >>> Running parser test on ../../../../p4c/testdata/p4_16_samples/forloop5a.p4
 Error on parser: ../../../../p4c/testdata/p4_16_samples/forloop5a.p4
-../../../../p4c/testdata/p4_16_samples/forloop5a.p4:20.52-20.53: syntax error at line 1, column 1360
+../../../../p4c/testdata/p4_16_samples/forloop5a.p4:20.52-20.53: syntax error
 
 >>> Running parser test on ../../../../p4c/testdata/p4_16_samples/forloop6.p4
 Parser success: ../../../../p4c/testdata/p4_16_samples/forloop6.p4

--- a/p4spec/test/test.ml
+++ b/p4spec/test/test.ml
@@ -35,6 +35,7 @@ exception TestCheckErr of string * region * float
 exception TestCheckNegErr of float
 exception TestUnknownErr of float
 exception TestParseErr of string * region * float
+exception TestParseRoundtripErr of float
 
 (* Timer *)
 
@@ -81,10 +82,15 @@ let collect_excludes (paths_exclude : string list) =
 let run_parser includes filename =
   let time_start = start () in
   try
-    let _program = Parsing.Parse.parse_file includes filename in
+    let program_1 = Parsing.Parse.parse_file includes filename in
+    let file' = Format.asprintf "%a\n" Parsing.Pp.pp_value program_1 in
+    let program_2 = Parsing.Parse.parse_string filename file' in
+    if not (Il.Eq.eq_value program_1 program_2) then
+      raise (TestParseRoundtripErr time_start);
     time_start
   with
   | ParseError (at, msg) -> raise (TestParseErr (msg, at, time_start))
+  | TestParseRoundtripErr t -> raise (TestParseRoundtripErr t)
   | _ -> raise (TestUnknownErr time_start)
 
 let run_parser_test stat includes excludes filename =
@@ -111,6 +117,19 @@ let run_parser_test stat includes excludes filename =
         let log =
           Format.asprintf "Error on parser: %s\n%s" filename
             (string_of_error at msg)
+        in
+        log |> print_endline;
+        Format.eprintf "%s\n" log;
+        Format.eprintf ">>> took %.6f seconds\n" duration;
+        {
+          stat with
+          durations = duration :: stat.durations;
+          fail_run = stat.fail_run + 1;
+        }
+    | TestParseRoundtripErr time_start ->
+        let duration = stop time_start in
+        let log =
+          Format.asprintf "Error on parser: roundtrip fail in %s" filename
         in
         log |> print_endline;
         Format.eprintf "%s\n" log;

--- a/p4spec/test/test.ml
+++ b/p4spec/test/test.ml
@@ -35,7 +35,7 @@ exception TestCheckErr of string * region * float
 exception TestCheckNegErr of float
 exception TestUnknownErr of float
 exception TestParseErr of string * region * float
-exception TestParseRoundtripErr of float
+exception TestParseRoundtripErr of string * string * float
 
 (* Timer *)
 
@@ -79,6 +79,31 @@ let collect_excludes (paths_exclude : string list) =
 
 (* Parser test *)
 
+let show_diff str1 str2 =
+  let temp1 = Filename.temp_file "original" ".p4" in
+  let temp2 = Filename.temp_file "roundtrip" ".p4" in
+  let () =
+    let oc1 = open_out temp1 in
+    output_string oc1 str1;
+    close_out oc1;
+    let oc2 = open_out temp2 in
+    output_string oc2 str2;
+    close_out oc2
+  in
+  let diff_cmd = Printf.sprintf "diff -u %s %s || true" temp1 temp2 in
+  let diff_output =
+    let ic = Unix.open_process_in diff_cmd in
+    let result = In_channel.input_all ic in
+    let _ = Unix.close_process_in ic in
+    result
+  in
+  let () =
+    Sys.remove temp1;
+    Sys.remove temp2
+  in
+  if String.equal diff_output "" then "No differences found (but ASTs differ)"
+  else diff_output
+
 let run_parser includes filename =
   let time_start = start () in
   try
@@ -86,11 +111,12 @@ let run_parser includes filename =
     let file' = Format.asprintf "%a\n" Parsing.Pp.pp_value program_1 in
     let program_2 = Parsing.Parse.parse_string filename file' in
     if not (Il.Eq.eq_value program_1 program_2) then
-      raise (TestParseRoundtripErr time_start);
-    time_start
+      let file'' = Format.asprintf "%a\n" Parsing.Pp.pp_value program_2 in
+      raise (TestParseRoundtripErr (file', file'', time_start))
+    else time_start
   with
   | ParseError (at, msg) -> raise (TestParseErr (msg, at, time_start))
-  | TestParseRoundtripErr t -> raise (TestParseRoundtripErr t)
+  | TestParseRoundtripErr _ as err -> raise err
   | _ -> raise (TestUnknownErr time_start)
 
 let run_parser_test stat includes excludes filename =
@@ -126,10 +152,12 @@ let run_parser_test stat includes excludes filename =
           durations = duration :: stat.durations;
           fail_run = stat.fail_run + 1;
         }
-    | TestParseRoundtripErr time_start ->
+    | TestParseRoundtripErr (str1, str2, time_start) ->
         let duration = stop time_start in
+        let diff_output = show_diff str1 str2 in
         let log =
-          Format.asprintf "Error on parser: roundtrip fail in %s" filename
+          Format.asprintf "Error on parser: roundtrip fail in %s\n%s" filename
+            diff_output
         in
         log |> print_endline;
         Format.eprintf "%s\n" log;

--- a/p4spec/test/test.ml
+++ b/p4spec/test/test.ml
@@ -35,7 +35,7 @@ exception TestCheckErr of string * region * float
 exception TestCheckNegErr of float
 exception TestUnknownErr of float
 exception TestParseErr of string * region * float
-exception TestParseRoundtripErr of string * string * float
+exception TestParseRoundtripErr of string * float
 
 (* Timer *)
 
@@ -112,7 +112,8 @@ let run_parser includes filename =
     let program_2 = Parsing.Parse.parse_string filename file' in
     if not (Il.Eq.eq_value program_1 program_2) then
       let file'' = Format.asprintf "%a\n" Parsing.Pp.pp_value program_2 in
-      raise (TestParseRoundtripErr (file', file'', time_start))
+      let diff = show_diff file' file'' in
+      raise (TestParseRoundtripErr (diff, time_start))
     else time_start
   with
   | ParseError (at, msg) -> raise (TestParseErr (msg, at, time_start))
@@ -152,12 +153,11 @@ let run_parser_test stat includes excludes filename =
           durations = duration :: stat.durations;
           fail_run = stat.fail_run + 1;
         }
-    | TestParseRoundtripErr (str1, str2, time_start) ->
+    | TestParseRoundtripErr (diff, time_start) ->
         let duration = stop time_start in
-        let diff_output = show_diff str1 str2 in
         let log =
           Format.asprintf "Error on parser: roundtrip fail in %s\n%s" filename
-            diff_output
+            diff
         in
         log |> print_endline;
         Format.eprintf "%s\n" log;

--- a/p4spec/test/test.ml
+++ b/p4spec/test/test.ml
@@ -111,9 +111,7 @@ let run_parser includes filename =
     let file' = Format.asprintf "%a\n" Parsing.Pp.pp_value program_1 in
     let program_2 = Parsing.Parse.parse_string filename file' in
     if not (Il.Eq.eq_value program_1 program_2) then
-      let file'' = Format.asprintf "%a\n" Parsing.Pp.pp_value program_2 in
-      let diff = show_diff file' file'' in
-      raise (TestParseRoundtripErr (diff, time_start))
+      raise (TestParseRoundtripErr (file', time_start))
     else time_start
   with
   | ParseError (at, msg) -> raise (TestParseErr (msg, at, time_start))
@@ -153,11 +151,12 @@ let run_parser_test stat includes excludes filename =
           durations = duration :: stat.durations;
           fail_run = stat.fail_run + 1;
         }
-    | TestParseRoundtripErr (diff, time_start) ->
+    | TestParseRoundtripErr (str, time_start) ->
         let duration = stop time_start in
         let log =
-          Format.asprintf "Error on parser: roundtrip fail in %s\n%s" filename
-            diff
+          Format.asprintf
+            "Error on parser: roundtrip fail in %s\nParsed file:\n%s" filename
+            str
         in
         log |> print_endline;
         Format.eprintf "%s\n" log;


### PR DESCRIPTION
This PR implements a pretty printer of P4 programs parsed into IL values and a parser roundtrip test to check the correctness of the parser.

1. Pretty printer for IL values
An IL value `value` can be printed by calling `pp_value fmt value`. A P4 program is parsed to a `ListV` value of declarations, which are each printed by `pp_syntax_decl`. From here, each non-terminal value is another IL value, mostly one of `CaseV`, `ListV`, or `OptV`, where `pp_case_v`, `pp_list_v`, and `pp_opt_v` handle them, respectively.
- `pp_case_v`
Most of the IL values are wrapped into a `CaseV` value. As there are many different cases, another function, prefixed with `"pp_syntax_"`, is called to print the value, e.g. `pp_syntax_expr` for expressions, `pp_syntax_stmt` for statements, etc. Within each function, a value is flattened to its ID, mixop, and non-terminal values to classify its syntax. Finally, each value is formatted as a string, where the non-terminal values are formatted by another call to `pp_case_v`, `pp_list_v`, ..., depending on their type.
- `pp_list_v`
When a `ListV` value is printed with `pp_list_v`, the separation character needs to be specified (the ones that were used in the code are `SpaceSep`, `Nl`, `Comma`, and `CommaNl`). The level is also needed if the separater involves a new line. Similar to `pp_case_v`, `pp_list_v` reads the ID of the value and decides which function should be used to print each element of the list. For example, the elements of a list of identifiers or parameters can all be handled by `pp_case_v`. The elements of a list of declarations, i.e., a P4 program, are printed with `pp_syntax_decl`.
- `pp_opt_v`
`pp_opt_v` prints the inner value of a `OptV` if it has one. The printer for the inner value `pp_v` should be specified, and an optional postfix can be given. Nothing is printed if the value holds `None`. For example, if `opt_const` is an optional `const` qualifer in P4, `Format.fprintf fmt "%a" (pp_opt_v ~postfix:" " pp_case_v) opt_const` will print either `"const "` or nothing to `fmt`.

2. Parser roundtrip test
`make test-spec` now runs a parser roundtrip test. The test parses a P4 program to an IL value `program_1`, prints it and parses it again to another IL value `program_2`. If these two values are equivalent, the roundtrip test successes, otherwise fails. Currently, the test results show a 1273/1278 (99.61%) pass rate with the test base `p4c/testdata/p4_16_samples`.