### PR TITLE
Implicit type casting of serializable enums

### DIFF
--- a/excludes/exclude-spec-discussion/impl-cast-directionless.exclude
+++ b/excludes/exclude-spec-discussion/impl-cast-directionless.exclude
@@ -1,4 +1,3 @@
-p4c/testdata/p4_16_samples/dash/dash-pipeline-pna-dpdk.p4
 p4c/testdata/p4_16_samples/dash/dash-pipeline-v1model-bmv2.p4
 p4c/testdata/p4_16_samples/omec/up4.p4
 p4c/testdata/p4_16_samples/bfd_offload.p4

--- a/p4spec/test/elab.expected
+++ b/p4spec/test/elab.expected
@@ -9871,7 +9871,7 @@ relation Decl_ok: `%%|-%:%%`(cursor, context, decl, context, declIL)
       -- (let id_s = $concat_text([id, ".", member]))*{id_s <- id_s*, member <- member*}
       -- let typ_s = `SEnumT%%%`_datatyp(id, typ, (member, val_s)*{member <- member*, val_s <- val_s*}) as typ
       -- (let styp_s = `%%%%`_styp(typ_s, `NO`_dir(), `LCTK`_ctk(), ?(val_s)))*{styp_s <- styp_s*, val_s <- val_s*}
-      -- let C_2 = $add_styps(`GLOBAL`_cursor(), C_1, id_s*{id_s <- id_s*}, styp_s*{styp_s <- styp_s*})
+      -- let C_2 = $add_styps(`GLOBAL`_cursor(), C_0, id_s*{id_s <- id_s*}, styp_s*{styp_s <- styp_s*})
       -- let td = `MonoD%`_monotypdef(typ_s) as typdef
       -- if TypeDef_wf: `%|-%`($bound_tids(`GLOBAL`_cursor(), C_0), td) holds
       -- let C_3 = $add_typdef(`GLOBAL`_cursor(), C_2, id, td)
@@ -10956,16 +10956,53 @@ def $reduce_senums_binary(exprIL, exprIL, $check_binary(typ, typ) : bool) : (exp
    clause 3(exprIL_a, exprIL_b, $check_binary) = ?()
       -- otherwise
 
-;; ../../../../spec/4d2-typing-subtyping.watsup:358.1-359.32
+;; ../../../../spec/4d2-typing-subtyping.watsup:357.1-357.35
+def $reduce_senum_type(typ) : typ? =
+
+   ;; ../../../../spec/4d2-typing-subtyping.watsup:360.1-362.30
+   clause 0(typ) = ?(typ')
+      -- let typ' = $reduce_senum_type'(typ)
+      -- if ~Type_alpha: `%~~%`(typ, typ') holds
+
+   ;; ../../../../spec/4d2-typing-subtyping.watsup:364.1-365.15
+   clause 1(typ) = ?()
+      -- otherwise
+
+;; ../../../../spec/4d2-typing-subtyping.watsup:358.1-358.35
+def $reduce_senum_type'(typ) : typ =
+
+   ;; ../../../../spec/4d2-typing-subtyping.watsup:367.1-369.42
+   clause 0(typ) = typ''
+      -- let typ''' = typ
+      -- if typ''' <: datatyp
+      -- let datatyp = typ''' as datatyp
+      -- if datatyp matches `SEnumT%%%`
+      -- let `SEnumT%%%`_datatyp(_id, typ', _(member, val)*{_(member, val) <- _(member, val)*}) = datatyp
+      -- let typ'' = $reduce_senum_type'(typ')
+
+   ;; ../../../../spec/4d2-typing-subtyping.watsup:371.1-373.45
+   clause 1(typ) = `SeqT%`_synthtyp(typ''*{typ'' <- typ''*}) as typ
+      -- let typ''' = typ
+      -- if typ''' <: synthtyp
+      -- let synthtyp = typ''' as synthtyp
+      -- if synthtyp matches `SeqT%`
+      -- let `SeqT%`_synthtyp(typ'*{typ' <- typ'*}) = synthtyp
+      -- (let typ'' = $reduce_senum_type'(typ'))*{typ' <- typ'*, typ'' <- typ''*}
+
+   ;; ../../../../spec/4d2-typing-subtyping.watsup:375.1-376.15
+   clause 2(typ) = typ
+      -- otherwise
+
+;; ../../../../spec/4d2-typing-subtyping.watsup:379.1-380.32
 def $coerce_binary(exprIL, exprIL) : (exprIL, exprIL)? =
 
-   ;; ../../../../spec/4d2-typing-subtyping.watsup:361.1-364.32
+   ;; ../../../../spec/4d2-typing-subtyping.watsup:382.1-385.32
    clause 0(exprIL_a, exprIL_b) = ?((exprIL_a, exprIL_b))
       -- let `(%;%)`_annotIL(typ_a, _ctk) = $annot(exprIL_a)
       -- let `(%;%)`_annotIL(typ_b, _ctk') = $annot(exprIL_b)
       -- if Type_alpha: `%~~%`(typ_a, typ_b) holds
 
-   ;; ../../../../spec/4d2-typing-subtyping.watsup:366.1-371.57
+   ;; ../../../../spec/4d2-typing-subtyping.watsup:387.1-392.57
    clause 1(exprIL_a, exprIL_b) = ?((exprIL_a', exprIL_b))
       -- let `(%;%)`_annotIL(typ_a, ctk_a) = $annot(exprIL_a)
       -- let `(%;%)`_annotIL(typ_b, _ctk) = $annot(exprIL_b)
@@ -10973,7 +11010,7 @@ def $coerce_binary(exprIL, exprIL) : (exprIL, exprIL)? =
       -- if Sub_impl: `%<<%`(typ_a, typ_b) holds
       -- let exprIL_a' = `CastE%%%`_exprIL(typ_b, exprIL_a, `(%;%)`_annotIL(typ_b, ctk_a))
 
-   ;; ../../../../spec/4d2-typing-subtyping.watsup:373.1-379.57
+   ;; ../../../../spec/4d2-typing-subtyping.watsup:394.1-400.57
    clause 2(exprIL_a, exprIL_b) = ?((exprIL_a, exprIL_b'))
       -- let `(%;%)`_annotIL(typ_a, _ctk) = $annot(exprIL_a)
       -- let `(%;%)`_annotIL(typ_b, ctk_b) = $annot(exprIL_b)
@@ -10982,25 +11019,55 @@ def $coerce_binary(exprIL, exprIL) : (exprIL, exprIL)? =
       -- if Sub_impl: `%<<%`(typ_b, typ_a) holds
       -- let exprIL_b' = `CastE%%%`_exprIL(typ_a, exprIL_b, `(%;%)`_annotIL(typ_a, ctk_b))
 
-   ;; ../../../../spec/4d2-typing-subtyping.watsup:381.1-382.15
-   clause 3(exprIL_a, exprIL_b) = ?()
+   ;; ../../../../spec/4d2-typing-subtyping.watsup:402.1-410.70
+   clause 3(exprIL_a, exprIL_b) = ?((exprIL_a'', exprIL_b'))
+      -- let `(%;%)`_annotIL(typ_a, ctk_a) = $annot(exprIL_a)
+      -- let `(%;%)`_annotIL(typ_b, _ctk) = $annot(exprIL_b)
+      -- if ~Type_alpha: `%~~%`(typ_a, typ_b) holds
+      -- if ~Sub_impl: `%<<%`(typ_a, typ_b) holds
+      -- if ~Sub_impl: `%<<%`(typ_b, typ_a) holds
+      -- let typ?{typ <- typ?} = $reduce_senum_type(typ_a)
+      -- if typ?{typ <- typ?} matches (_)
+      -- let ?(typ_a') = typ?{typ <- typ?}
+      -- let exprIL_a' = `CastE%%%`_exprIL(typ_a', exprIL_a, `(%;%)`_annotIL(typ_a', ctk_a))
+      -- let (exprIL, exprIL)?{(exprIL, exprIL) <- (exprIL, exprIL)?} = $coerce_binary(exprIL_a', exprIL_b)
+      -- if (exprIL, exprIL)?{(exprIL, exprIL) <- (exprIL, exprIL)?} matches (_)
+      -- let ?((exprIL_a'', exprIL_b')) = (exprIL, exprIL)?{(exprIL, exprIL) <- (exprIL, exprIL)?}
+
+   ;; ../../../../spec/4d2-typing-subtyping.watsup:412.1-420.70
+   clause 4(exprIL_a, exprIL_b) = ?((exprIL_a', exprIL_b''))
+      -- let `(%;%)`_annotIL(typ_a, _ctk) = $annot(exprIL_a)
+      -- let `(%;%)`_annotIL(typ_b, ctk_b) = $annot(exprIL_b)
+      -- if ~Type_alpha: `%~~%`(typ_a, typ_b) holds
+      -- if ~Sub_impl: `%<<%`(typ_a, typ_b) holds
+      -- if ~Sub_impl: `%<<%`(typ_b, typ_a) holds
+      -- let typ?{typ <- typ?} = $reduce_senum_type(typ_b)
+      -- if typ?{typ <- typ?} matches (_)
+      -- let ?(typ_b') = typ?{typ <- typ?}
+      -- let exprIL_b' = `CastE%%%`_exprIL(typ_b', exprIL_b, `(%;%)`_annotIL(typ_b', ctk_b))
+      -- let (exprIL, exprIL)?{(exprIL, exprIL) <- (exprIL, exprIL)?} = $coerce_binary(exprIL_a, exprIL_b')
+      -- if (exprIL, exprIL)?{(exprIL, exprIL) <- (exprIL, exprIL)?} matches (_)
+      -- let ?((exprIL_a', exprIL_b'')) = (exprIL, exprIL)?{(exprIL, exprIL) <- (exprIL, exprIL)?}
+
+   ;; ../../../../spec/4d2-typing-subtyping.watsup:422.1-423.15
+   clause 5(exprIL_a, exprIL_b) = ?()
       -- otherwise
 
-;; ../../../../spec/4d2-typing-subtyping.watsup:385.1-386.31
+;; ../../../../spec/4d2-typing-subtyping.watsup:426.1-427.31
 def $coerce_assign(exprIL, typ) : exprIL? =
 
-   ;; ../../../../spec/4d2-typing-subtyping.watsup:388.1-390.32
+   ;; ../../../../spec/4d2-typing-subtyping.watsup:429.1-431.32
    clause 0(exprIL, typ_t) = ?(exprIL)
       -- let `(%;%)`_annotIL(typ_f, _ctk) = $annot(exprIL)
       -- if Type_alpha: `%~~%`(typ_f, typ_t) holds
 
-   ;; ../../../../spec/4d2-typing-subtyping.watsup:392.1-395.30
+   ;; ../../../../spec/4d2-typing-subtyping.watsup:433.1-436.30
    clause 1(exprIL, typ_t) = ?(`CastE%%%`_exprIL(typ_t, exprIL, `(%;%)`_annotIL(typ_t, ctk_f)))
       -- let `(%;%)`_annotIL(typ_f, ctk_f) = $annot(exprIL)
       -- if ~Type_alpha: `%~~%`(typ_f, typ_t) holds
       -- if Sub_impl: `%<<%`(typ_f, typ_t) holds
 
-   ;; ../../../../spec/4d2-typing-subtyping.watsup:397.1-398.15
+   ;; ../../../../spec/4d2-typing-subtyping.watsup:438.1-439.15
    clause 2(exprIL, typ_t) = ?()
       -- otherwise
 

--- a/p4spec/test/run_il_neg_p4c.expected
+++ b/p4spec/test/run_il_neg_p4c.expected
@@ -159,7 +159,7 @@ Error on typecheck: ../../../../p4c/testdata/p4_16_errors/duplicate-label.p4
 
 >>> Running typing test on ../../../../p4c/testdata/p4_16_errors/enumCast.p4
 Error on typecheck: ../../../../p4c/testdata/p4_16_errors/enumCast.p4
-../../../../spec/4g-typing-decl.watsup:308.15-308.24: function was not matched
+../../../../spec/4f-typing-stmt.watsup:272.6-272.13: relation was not matched
 
 >>> Running typing test on ../../../../p4c/testdata/p4_16_errors/equality-fail.p4
 Error on typecheck: ../../../../p4c/testdata/p4_16_errors/equality-fail.p4

--- a/p4spec/test/run_il_pos_p4c.expected
+++ b/p4spec/test/run_il_pos_p4c.expected
@@ -320,7 +320,7 @@ Typecheck success: ../../../../p4c/testdata/p4_16_samples/csum_ubpf.p4
 Typecheck success: ../../../../p4c/testdata/p4_16_samples/custom-type-restricted-fields.p4
 
 >>> Running typing test on ../../../../p4c/testdata/p4_16_samples/dash/dash-pipeline-pna-dpdk.p4
-Excluding file: ../../../../p4c/testdata/p4_16_samples/dash/dash-pipeline-pna-dpdk.p4
+Typecheck success: ../../../../p4c/testdata/p4_16_samples/dash/dash-pipeline-pna-dpdk.p4
 
 >>> Running typing test on ../../../../p4c/testdata/p4_16_samples/dash/dash-pipeline-v1model-bmv2.p4
 Excluding file: ../../../../p4c/testdata/p4_16_samples/dash/dash-pipeline-v1model-bmv2.p4
@@ -482,17 +482,6 @@ Excluding file: ../../../../p4c/testdata/p4_16_samples/factory2.p4
 Typecheck success: ../../../../p4c/testdata/p4_16_samples/filter.p4
 
 >>> Running typing test on ../../../../p4c/testdata/p4_16_samples/flag_lost-bmv2.p4
-negative inner acc: -0.051658
-negative inner acc: -0.050832
-negative inner acc: -0.050587
-negative inner acc: -0.050513
-negative inner acc: -0.050490
-negative inner acc: -0.050272
-negative inner acc: -0.050127
-negative inner acc: -0.050067
-negative inner acc: -0.050047
-negative inner acc: -0.044239
-negative inner acc: -0.044122
 Typecheck success: ../../../../p4c/testdata/p4_16_samples/flag_lost-bmv2.p4
 
 >>> Running typing test on ../../../../p4c/testdata/p4_16_samples/flowlet_switching-bmv2.p4
@@ -3846,4 +3835,4 @@ Typecheck success: ../../../../p4c/testdata/p4_16_samples/xdp_vlan_push_pop_ebpf
 >>> Running typing test on ../../../../p4c/testdata/p4_16_samples/xor_test.p4
 Typecheck success: ../../../../p4c/testdata/p4_16_samples/xor_test.p4
 
-Running typing: [EXCLUDE] 223/1278 (17.45%) [PASS] 1055/1278 (82.55%) [FAIL] 0/1278 (0.00%)
+Running typing: [EXCLUDE] 222/1278 (17.37%) [PASS] 1056/1278 (82.63%) [FAIL] 0/1278 (0.00%)

--- a/p4spec/test/run_sl_neg_p4c.expected
+++ b/p4spec/test/run_sl_neg_p4c.expected
@@ -159,7 +159,7 @@ Error on typecheck: ../../../../p4c/testdata/p4_16_errors/duplicate-label.p4
 
 >>> Running typing test on ../../../../p4c/testdata/p4_16_errors/enumCast.p4
 Error on typecheck: ../../../../p4c/testdata/p4_16_errors/enumCast.p4
-../../../../spec/4g-typing-decl.watsup:308.15-308.24: function was not matched
+../../../../spec/4f-typing-stmt.watsup:272.6-272.13: relation was not matched
 
 >>> Running typing test on ../../../../p4c/testdata/p4_16_errors/equality-fail.p4
 Error on typecheck: ../../../../p4c/testdata/p4_16_errors/equality-fail.p4

--- a/p4spec/test/run_sl_pos_p4c.expected
+++ b/p4spec/test/run_sl_pos_p4c.expected
@@ -320,7 +320,7 @@ Typecheck success: ../../../../p4c/testdata/p4_16_samples/csum_ubpf.p4
 Typecheck success: ../../../../p4c/testdata/p4_16_samples/custom-type-restricted-fields.p4
 
 >>> Running typing test on ../../../../p4c/testdata/p4_16_samples/dash/dash-pipeline-pna-dpdk.p4
-Excluding file: ../../../../p4c/testdata/p4_16_samples/dash/dash-pipeline-pna-dpdk.p4
+Typecheck success: ../../../../p4c/testdata/p4_16_samples/dash/dash-pipeline-pna-dpdk.p4
 
 >>> Running typing test on ../../../../p4c/testdata/p4_16_samples/dash/dash-pipeline-v1model-bmv2.p4
 Excluding file: ../../../../p4c/testdata/p4_16_samples/dash/dash-pipeline-v1model-bmv2.p4
@@ -3835,4 +3835,4 @@ Typecheck success: ../../../../p4c/testdata/p4_16_samples/xdp_vlan_push_pop_ebpf
 >>> Running typing test on ../../../../p4c/testdata/p4_16_samples/xor_test.p4
 Typecheck success: ../../../../p4c/testdata/p4_16_samples/xor_test.p4
 
-Running typing: [EXCLUDE] 223/1278 (17.45%) [PASS] 1055/1278 (82.55%) [FAIL] 0/1278 (0.00%)
+Running typing: [EXCLUDE] 222/1278 (17.37%) [PASS] 1056/1278 (82.63%) [FAIL] 0/1278 (0.00%)

--- a/p4spec/test/struct.expected
+++ b/p4spec/test/struct.expected
@@ -14272,7 +14272,7 @@ relation Decl_ok: p', C'''', decl''
 
                 3. (Let styp_s be (typ_s (NO) (LCTK) ?(val_s)))*
 
-                4. (Let C_2 be $add_styps((GLOBAL), C_1, id_s*, styp_s*))
+                4. (Let C_2 be $add_styps((GLOBAL), C'''', id_s*, styp_s*))
 
                 5. (Let td be ((MonoD typ_s) as typdef))
 
@@ -16218,7 +16218,53 @@ def $reduce_senums_binary(exprIL_a, exprIL_b, $check_binary)
 
   1. Return ?()
 
-;; ../../../../spec/4d2-typing-subtyping.watsup:358.1-359.32
+;; ../../../../spec/4d2-typing-subtyping.watsup:357.1-357.35
+def $reduce_senum_type(typ)
+
+1. (Let typ' be $reduce_senum_type'(typ))
+
+2. If (~(Type_alpha: typ ~~ typ' holds)), then
+
+  1. Return ?(typ')
+
+3. Otherwise
+
+  1. Return ?()
+
+;; ../../../../spec/4d2-typing-subtyping.watsup:358.1-358.35
+def $reduce_senum_type'(typ)
+
+1. Case analysis on typ
+
+  1. Case (% has type datatyp)
+
+    1. (Let datatyp be (typ as datatyp))
+
+    2. If ((datatyp matches pattern `SEnumT%%%`)), then
+
+      1. (Let (SEnumT _id typ' _(member, val)*) be datatyp)
+
+      2. (Let typ'' be $reduce_senum_type'(typ'))
+
+      3. Return typ''
+
+  2. Case (% has type synthtyp)
+
+    1. (Let synthtyp be (typ as synthtyp))
+
+    2. If ((synthtyp matches pattern `SeqT%`)), then
+
+      1. (Let (SeqT typ'*) be synthtyp)
+
+      2. (Let typ'' be $reduce_senum_type'(typ'))*
+
+      3. Return ((SeqT typ''*) as typ)
+
+2. Otherwise
+
+  1. Return typ
+
+;; ../../../../spec/4d2-typing-subtyping.watsup:379.1-380.32
 def $coerce_binary(exprIL_a, exprIL_b)
 
 1. (Let (( typ_a ; _ctk )) be $annot(exprIL_a))
@@ -16243,17 +16289,53 @@ def $coerce_binary(exprIL_a, exprIL_b)
 
       2. Case false
 
-        1. If ((Sub_impl: typ_b << typ_a holds)), then
+        1. Case analysis on (Sub_impl: typ_b << typ_a holds)
 
-          1. (Let exprIL_b' be (CastE typ_a exprIL_b (( typ_a ; _ctk' ))))
+          1. Case true
 
-          2. Return ?((exprIL_a, exprIL_b'))
+            1. (Let exprIL_b' be (CastE typ_a exprIL_b (( typ_a ; _ctk' ))))
+
+            2. Return ?((exprIL_a, exprIL_b'))
+
+          2. Case false
+
+            1. (Let typ? be $reduce_senum_type(typ_a))
+
+            2. If ((typ? matches pattern (_))), then
+
+              1. (Let ?(typ_a') be typ?)
+
+              2. (Let exprIL_a' be (CastE typ_a' exprIL_a (( typ_a' ; _ctk' ))))
+
+              3. (Let (exprIL, exprIL)? be $coerce_binary(exprIL_a', exprIL_b))
+
+              4. If (((exprIL, exprIL)? matches pattern (_))), then
+
+                1. (Let ?((exprIL_a'', exprIL_b')) be (exprIL, exprIL)?)
+
+                2. Return ?((exprIL_a'', exprIL_b'))
+
+            3. (Let typ? be $reduce_senum_type(typ_b))
+
+            4. If ((typ? matches pattern (_))), then
+
+              1. (Let ?(typ_b') be typ?)
+
+              2. (Let exprIL_b' be (CastE typ_b' exprIL_b (( typ_b' ; _ctk' ))))
+
+              3. (Let (exprIL, exprIL)? be $coerce_binary(exprIL_a, exprIL_b'))
+
+              4. If (((exprIL, exprIL)? matches pattern (_))), then
+
+                1. (Let ?((exprIL_a', exprIL_b'')) be (exprIL, exprIL)?)
+
+                2. Return ?((exprIL_a', exprIL_b''))
 
 4. Otherwise
 
   1. Return ?()
 
-;; ../../../../spec/4d2-typing-subtyping.watsup:385.1-386.31
+;; ../../../../spec/4d2-typing-subtyping.watsup:426.1-427.31
 def $coerce_assign(exprIL, typ_t)
 
 1. (Let (( typ_f ; _ctk )) be $annot(exprIL))

--- a/spec/4d2-typing-subtyping.watsup
+++ b/spec/4d2-typing-subtyping.watsup
@@ -354,6 +354,27 @@ def $reduce_senums_binary(exprIL_a, exprIL_b, def $check_binary) = (exprIL_a'', 
 def $reduce_senums_binary(exprIL_a, exprIL_b, def $check_binary) = eps
   -- otherwise
 
+dec $reduce_senum_type(typ) : typ?
+dec $reduce_senum_type'(typ) : typ
+
+def $reduce_senum_type(typ) = typ'
+  -- if typ' = $reduce_senum_type'(typ)
+  -- Type_alpha:/ typ ~~ typ'
+
+def $reduce_senum_type(typ) = eps
+  -- otherwise
+
+def $reduce_senum_type'(typ) = typ''
+  -- if SEnumT _ typ' _ = typ
+  -- if typ'' = $reduce_senum_type'(typ')
+  
+def $reduce_senum_type'(typ) = SeqT typ''*
+  -- if SeqT typ'* = typ
+  -- if (typ'' = $reduce_senum_type'(typ'))*
+
+def $reduce_senum_type'(typ) = typ
+  -- otherwise
+
 ;; (TODO) This should better be a relation
 dec $coerce_binary(exprIL, exprIL) : (exprIL, exprIL)?
     hint(show COERCE %1 AND %2)
@@ -377,6 +398,26 @@ def $coerce_binary(exprIL_a, exprIL_b) = (exprIL_a, exprIL_b')
   -- Sub_impl:/ typ_a << typ_b
   -- Sub_impl: typ_b << typ_a
   -- if exprIL_b' = CastE typ_a exprIL_b `(typ_a; ctk_b)
+
+def $coerce_binary(exprIL_a, exprIL_b) = (exprIL_a'', exprIL_b')
+  -- if `(typ_a; ctk_a) = $annot(exprIL_a)
+  -- if `(typ_b; _) = $annot(exprIL_b)
+  -- Type_alpha:/ typ_a ~~ typ_b
+  -- Sub_impl:/ typ_a << typ_b
+  -- Sub_impl:/ typ_b << typ_a
+  -- if typ_a' = $reduce_senum_type(typ_a)
+  -- if exprIL_a' = CastE typ_a' exprIL_a `(typ_a'; ctk_a)
+  -- if (exprIL_a'', exprIL_b') = $coerce_binary(exprIL_a', exprIL_b)
+
+def $coerce_binary(exprIL_a, exprIL_b) = (exprIL_a', exprIL_b'')
+  -- if `(typ_a; _) = $annot(exprIL_a)
+  -- if `(typ_b; ctk_b) = $annot(exprIL_b)
+  -- Type_alpha:/ typ_a ~~ typ_b
+  -- Sub_impl:/ typ_a << typ_b
+  -- Sub_impl:/ typ_b << typ_a
+  -- if typ_b' = $reduce_senum_type(typ_b)
+  -- if exprIL_b' = CastE typ_b' exprIL_b `(typ_b'; ctk_b)
+  -- if (exprIL_a', exprIL_b'') = $coerce_binary(exprIL_a, exprIL_b')
 
 def $coerce_binary(exprIL_a, exprIL_b) = eps
   -- otherwise

--- a/spec/4g-typing-decl.watsup
+++ b/spec/4g-typing-decl.watsup
@@ -335,7 +335,7 @@ rule Decl_ok/senumd:
   -- if typ_s = SEnumT id typ (member, val_s)*
   -- if (styp_s = typ_s NO LCTK val_s)*
   ----
-  -- if C_2 = $add_styps(GLOBAL, C_1, id_s*, styp_s*)
+  -- if C_2 = $add_styps(GLOBAL, C_0, id_s*, styp_s*)
   ----
   -- if td = MonoD typ_s
   -- TypeDef_wf: $bound_tids(GLOBAL, C_0) |- td


### PR DESCRIPTION
This PR adds support of implicit casts of serializable enums to their underlying types within comparison operators and a minor fix regarding serializable enums with overlapping element names.

1. Implicit casts of serializable enums
    Serializable enums can be compared with equality (`==`) and inequality (`!=`) operators with (1) another serializable enum with the same underlying type and (2) arbitrary-precision integers.
    - `$reduce_senum_typ(typ)`
        This function reduces serializable enum types to their underlying types, and also applies it recursively to tuple expressions (`SeqT` in SpecTec).
    - More definitions of function `$coerce_binary`
        If the types of the two expressions are not equal nor a subtype of one another, their types are reduced with `$reduce_senum_typ` and `$coerce_binary` retries to match their types.

2. Serializable enums with overlapping element names
    Fixes an error that occured in type checking when two different serializable enums have an element whose names overlap. The type checker now classifies `p4c/testdata/p4_16_samples/dash/dash-pipeline-pna-dpdk.p4` as a well-typed program.