### PR TITLE
Compile-time evaluation of field and index accesses

### DIFF
--- a/excludes/exclude-spec-discussion/compile-time-known-access.exclude
+++ b/excludes/exclude-spec-discussion/compile-time-known-access.exclude
@@ -1,4 +1,0 @@
-p4c/testdata/p4_16_samples/constStruct.p4
-p4c/testdata/p4_16_samples/struct.p4
-p4c/testdata/p4_16_samples/struct1.p4
-p4c/testdata/p4_16_samples/tuple3.p4

--- a/spec-concrete/2.1.1-value.watsup
+++ b/spec-concrete/2.1.1-value.watsup
@@ -39,7 +39,7 @@ syntax headerStackValue = `[ value* `# `( nat; nat ) ]
 syntax fieldValue = value id `;
 
 syntax structValue = STRUCT tid `{ fieldValue* }
-syntax headerValue = HEADER tid `{ fieldValue* }
+syntax headerValue = HEADER tid `{ bool fieldValue* }
 syntax headerUnionValue = HEADER_UNION tid `{ fieldValue* }
 
 syntax enumValue =

--- a/spec-concrete/2.3-compile-time-known.watsup
+++ b/spec-concrete/2.3-compile-time-known.watsup
@@ -15,7 +15,7 @@ def $join_ctk(ctk_a, ctk_b) = DYN
 
 dec $joins_ctk(ctk*) : ctk
 
-def $joins_ctk(eps) = DYN
+def $joins_ctk(eps) = LCTK
 def $joins_ctk(ctk) = ctk
 def $joins_ctk(ctk_a :: ctk_b) = $join_ctk(ctk_a, ctk_b)
 def $joins_ctk(ctk_a :: ctk_b :: ctk_c*) = $joins_ctk(ctk_d :: ctk_c*) 

--- a/spec-concrete/3-numerics.watsup
+++ b/spec-concrete/3-numerics.watsup
@@ -260,10 +260,11 @@ def $bin_eq(
   = (tid_a = tid_b)
     /\ $bin_eqs_fields((value_f_a, id_f_a)*, (value_f_b, id_f_b)*)
 def $bin_eq(
-    HEADER tid_a `{ (value_f_a id_f_a `;)* },
-    HEADER tid_b `{ (value_f_b id_f_b `;)* }
+    HEADER tid_a `{ b_a (value_f_a id_f_a `;)* },
+    HEADER tid_b `{ b_b (value_f_b id_f_b `;)* }
   )
   = (tid_a = tid_b)
+    /\ (b_a = b_b)
     /\ $bin_eqs_fields((value_f_a, id_f_a)*, (value_f_b, id_f_b)*)
 def $bin_eq(
     HEADER_UNION tid_a `{ (value_f_a id_f_a `;)* },
@@ -464,17 +465,17 @@ def $cast_op(typeIR, STRUCT tid `{ (value_f id_f `;)* })
 
 ;;; Cast from header
 
-dec $cast_header(typeIR, tid, (value, id)*) : value
-dec $cast_header'(typeIR, tid, (value, id)*) : value
+dec $cast_header(typeIR, tid, bool, (value, id)*) : value
+dec $cast_header'(typeIR, tid, bool, (value, id)*) : value
 
-def $cast_header(typeIR, tid, (value_f, id_f)*)
-  = $cast_header'($canon(typeIR), tid, (value_f, id_f)*)
+def $cast_header(typeIR, tid, b, (value_f, id_f)*)
+  = $cast_header'($canon(typeIR), tid, b, (value_f, id_f)*)
 
-def $cast_header'(HEADER tid `{ _ }, tid, (value_f, id_f)*)
-  = HEADER tid `{ (value_f id_f `;)* }
+def $cast_header'(HEADER tid `{ _ }, tid, b, (value_f, id_f)*)
+  = HEADER tid `{ b (value_f id_f `;)* }
 
-def $cast_op(typeIR, HEADER tid `{ (value_f id_f `;)* })
-  = $cast_header(typeIR, tid, (value_f, id_f)*)
+def $cast_op(typeIR, HEADER tid `{ b (value_f id_f `;)* })
+  = $cast_header(typeIR, tid, b, (value_f, id_f)*)
 
 ;;; Cast from serializable enum field
 
@@ -504,7 +505,7 @@ def $cast_sequence'(STRUCT tid `{ (typeIR_f id_f `;)* }, value*)
   -- if (value_cast = $cast_op(typeIR_f, value))*
 
 def $cast_sequence'(HEADER tid `{ (typeIR_f id_f `;)* }, value*)
-  = HEADER tid `{ (value_cast id_f `;)* }
+  = HEADER tid `{ true (value_cast id_f `;)* }
   -- if (value_cast = $cast_op(typeIR_f, value))*
 
 def $cast_op(typeIR, SEQ `( value* )) = $cast_sequence(typeIR, value*)
@@ -531,7 +532,7 @@ def $cast_record'(
     HEADER tid `{ (typeIR_t_f id_t_f `;)* },
     (value_f, id_f)*
   )
-  = HEADER tid `{ (value_f_cast id_f `;)* }
+  = HEADER tid `{ true (value_f_cast id_f `;)* }
   -- if (value_f' = $find_map<id, value>(`{ (id_f `: value_f)* }, id_t_f))*
   -- if (value_f_cast = $cast_op(typeIR_t_f, value_f'))*
 
@@ -625,7 +626,7 @@ def $default'(STRUCT tid `{ (typeIR_f id_f `;)* })
   = STRUCT tid `{ ($default(typeIR_f) id_f `;)* }
 
 def $default'(HEADER tid `{ (typeIR_f id_f `;)* })
-  = HEADER tid `{ ($default(typeIR_f) id_f `;)* }
+  = HEADER tid `{ false ($default(typeIR_f) id_f `;)* }
 
 def $default'(HEADER_UNION tid `{ (typeIR_f id_f `;)* })
   = HEADER_UNION tid `{ ($default(typeIR_f) id_f `;)* }

--- a/spec-concrete/3-numerics.watsup
+++ b/spec-concrete/3-numerics.watsup
@@ -544,7 +544,20 @@ def $cast_op(typeIR, RECORD `{ (value id `;)* })
 
 def $cast_op(typeIR, DEFAULT) = $default(typeIR)
 
-;; Cast from invalueid
+;; Cast from invalid
+
+dec $cast_invalid(typeIR) : value
+dec $cast_invalid'(typeIR) : value
+
+def $cast_invalid(typeIR) = $cast_invalid'($canon(typeIR))
+
+def $cast_invalid'(typeIR) = $default(typeIR)
+  -- if HEADER _ `{ (_ _ `;)* } = typeIR
+
+def $cast_invalid'(typeIR) = $default(typeIR)
+  -- if HEADER_UNION _ `{ (_ _ `;)* } = typeIR
+
+def $cast_op(typeIR, `{#}) = $cast_invalid(typeIR)
 
 ;; Cast from set
 

--- a/spec-concrete/5.06.1-expression-static-eval.watsup
+++ b/spec-concrete/5.06.1-expression-static-eval.watsup
@@ -301,7 +301,7 @@ rule Eval_static/memberAccessExpressionIR-typedExpressionIR-header:
   p C |- (typedExpressionIR_base `. nameIR) `# `( typeIR_base _ )
       ~> value
   -- Eval_static: p C |- typedExpressionIR_base ~> value_base
-  -- if HEADER _ `{ (value_field id_field `;)* } = value_base
+  -- if HEADER _ `{ _ (value_field id_field `;)* } = value_base
   -- if value = $assoc_<id, value>(nameIR, (id_field, value_field)*)
 
 ;; local compile-time known header unions do not seem to be constructable

--- a/spec-concrete/5.06.1-expression-static-eval.watsup
+++ b/spec-concrete/5.06.1-expression-static-eval.watsup
@@ -290,11 +290,52 @@ rule Eval_static/memberAccessExpressionIR-typedExpressionIR-stack-size:
       ~> D n_size
   -- if _ `[ n_size ] = typeIR_base
 
+rule Eval_static/memberAccessExpressionIR-typedExpressionIR-struct:
+  p C |- (typedExpressionIR_base `. nameIR) `# `( typeIR_base _ )
+      ~> value
+  -- Eval_static: p C |- typedExpressionIR_base ~> value_base
+  -- if STRUCT _ `{ (value_field id_field `;)* } = value_base
+  -- if value = $assoc_<id, value>(nameIR, (id_field, value_field)*)
+
+rule Eval_static/memberAccessExpressionIR-typedExpressionIR-header:
+  p C |- (typedExpressionIR_base `. nameIR) `# `( typeIR_base _ )
+      ~> value
+  -- Eval_static: p C |- typedExpressionIR_base ~> value_base
+  -- if HEADER _ `{ (value_field id_field `;)* } = value_base
+  -- if value = $assoc_<id, value>(nameIR, (id_field, value_field)*)
+
+;; local compile-time known header unions do not seem to be constructable
+rule Eval_static/memberAccessExpressionIR-typedExpressionIR-headerunion:
+  p C |- (typedExpressionIR_base `. nameIR) `# `( typeIR_base _ )
+      ~> value
+  -- Eval_static: p C |- typedExpressionIR_base ~> value_base
+  -- if HEADER_UNION _ `{ (value_field id_field `;)* } = value_base
+  -- if value = $assoc_<id, value>(nameIR, (id_field, value_field)*)
+
 ;;;;; indexAccessExpressionIR
 ;;;;; syntax indexAccessExpressionIR
 
 ;;;;;; typedExpressionIR `[ typedExpressionIR ]
-;;;;;; tuple or stack accesses are not evaluated statically
+
+rule Eval_static/indexAccessExpressionIR-tuple:
+  p C |- (typedExpressionIR_base `[ typedExpressionIR_index ]) `# `( _ _ )
+      ~> value
+  -- Eval_static: p C |- typedExpressionIR_base ~> value_base
+  -- Eval_static: p C |- typedExpressionIR_index ~> value_index
+  -- if `( value_e* ) = value_base
+  -- if n_index = $to_number(value_index)
+  -- if $(n_index < |value_e*|)
+  -- if value = value_e*[n_index]
+
+rule Eval_static/indexAccessExpressionIR-stack:
+  p C |- (typedExpressionIR_base `[ typedExpressionIR_index ]) `# `( _ _ )
+      ~> value
+  -- Eval_static: p C |- typedExpressionIR_base ~> value_base
+  -- Eval_static: p C |- typedExpressionIR_index ~> value_index
+  -- if `[ value_e* `# `( _; _ ) ] = value_base
+  -- if n_index = $to_number(value_index)
+  -- if $(n_index < |value_e*|)
+  -- if value = value_e*[n_index]
 
 ;;;;;; typedExpressionIR `[ typedExpressionIR `: typedExpressionIR ]
 

--- a/spec-concrete/5.06.2-typing-expression.watsup
+++ b/spec-concrete/5.06.2-typing-expression.watsup
@@ -811,14 +811,14 @@ rule Expr_ok/accessExpression-memberAccessExpression-expression-struct:
   ---- ;; check expression
   -- Expr_ok: p C |- expression_base : typedExpressionIR_base
   ---- ;; fetch annotation
-  -- if _ `# `( typeIR_base _ ) = typedExpressionIR_base
+  -- if _ `# `( typeIR_base ctk_base ) = typedExpressionIR_base
   ---- ;; check that the expression is a struct
   -- if STRUCT _ `{ (typeIR_f nameIR_f `;)* } = $canon(typeIR_base)
   ---- ;; find the field
   -- if nameIR = $name(member)
   -- if typeIR = $assoc_<nameIR, typeIR>(nameIR, (nameIR_f, typeIR_f)*)
   ---- ;; create typed expression
-  -- if expressionNoteIR = `( typeIR DYN )
+  -- if expressionNoteIR = `( typeIR ctk_base )
 
 rule Expr_ok/accessExpression-memberAccessExpression-expression-header:
   p C |- expression_base `. member
@@ -826,14 +826,14 @@ rule Expr_ok/accessExpression-memberAccessExpression-expression-header:
   ---- ;; check expression
   -- Expr_ok: p C |- expression_base : typedExpressionIR_base
   ---- ;; fetch annotation
-  -- if _ `# `( typeIR_base _ ) = typedExpressionIR_base
+  -- if _ `# `( typeIR_base ctk_base ) = typedExpressionIR_base
   ---- ;; check that the expression is a header
   -- if HEADER _ `{ (typeIR_f nameIR_f `;)* } = $canon(typeIR_base)
   ---- ;; find the field
   -- if nameIR = $name(member)
   -- if typeIR = $assoc_<nameIR, typeIR>(nameIR, (nameIR_f, typeIR_f)*)
   ---- ;; create typed expression
-  -- if expressionNoteIR = `( typeIR DYN )
+  -- if expressionNoteIR = `( typeIR ctk_base )
 
 rule Expr_ok/accessExpression-memberAccessExpression-expression-headerunion:
   p C |- expression_base `. member
@@ -841,14 +841,14 @@ rule Expr_ok/accessExpression-memberAccessExpression-expression-headerunion:
   ---- ;; check expression
   -- Expr_ok: p C |- expression_base : typedExpressionIR_base
   ---- ;; fetch annotation
-  -- if _ `# `( typeIR_base _ ) = typedExpressionIR_base
+  -- if _ `# `( typeIR_base ctk_base ) = typedExpressionIR_base
   ---- ;; check that the expression is a header union 
   -- if HEADER_UNION _ `{ (typeIR_f nameIR_f `;)* } = $canon(typeIR_base)
   ---- ;; find the field
   -- if nameIR = $name(member)
   -- if typeIR = $assoc_<nameIR, typeIR>(nameIR, (nameIR_f, typeIR_f)*)
   ---- ;; create typed expression
-  -- if expressionNoteIR = `( typeIR DYN )
+  -- if expressionNoteIR = `( typeIR ctk_base )
 
 rule Expr_ok/accessExpression-memberAccessExpression-expression-tablestruct:
   p C |- expression_base `. member
@@ -906,7 +906,7 @@ rule Expr_ok/indexAccessExpression-tuple:
   -- if n_index = $to_number(value_index)
   -- if $(n_index < |typeIR_e*|)
   ---- ;; create typed expression
-  -- if expressionNoteIR = `( typeIR_e*[n_index] DYN )
+  -- if expressionNoteIR = `( typeIR_e*[n_index] ctk_base )
 
 rule Expr_ok/indexAccessExpression-stack-lctk:
   p C |- expression_base `[ expression_index ]
@@ -933,7 +933,7 @@ rule Expr_ok/indexAccessExpression-stack-lctk:
   -- if n_index = $to_number(value_index)
   -- if $(n_index < n_size)
   ---- ;; create typed expression
-  -- if expressionNoteIR = `( typeIR DYN )
+  -- if expressionNoteIR = `( typeIR ctk_base )
 
 rule Expr_ok/indexAccessExpression-stack-non-lctk:
   p C |- expression_base `[ expression_index ]
@@ -957,7 +957,8 @@ rule Expr_ok/indexAccessExpression-stack-non-lctk:
   -- if typeIR `[ n_size ] = $canon(typeIR_base)
   -- if ctk_index =/= LCTK
   ---- ;; create typed expression
-  -- if expressionNoteIR = `( typeIR DYN )
+  -- if ctk = $join_ctk(ctk_base, ctk_index)
+  -- if expressionNoteIR = `( typeIR ctk )
 
 ;;;;; expression `[ expression `: expression ]
 


### PR DESCRIPTION
This PR expands (local) compile-time known values with field and index accesses. Also, a boolean value which represents the valid bit is added to header values. 
1. Compile-time known-ness of field and index accesses
    Values obtained by accessing a field of or indexing another value was previously considered dynamic (i.e. not compile-time known). Now following the P4 specification, the following expressions are considered (local) compile-time known and may be statically evaluated:
    - Accessing a field of a (local) compile-time known struct, header, or header union value.
    - Indexing a (local) compile-time known tuple or header stack value.

    With the above changes, `excludes/exclude-spec-discussion/compile-time-known-access.exclude` is removed.

    Some other minor fixes were involved:
    - `$joins_ctk(eps)` evaluates to `LCTK`.
    - Invalid header expressions(`{#}`) may be casted to another header type during static evaluation.
2. Valid bit of header values
    A boolean value is added to the syntax of a header value. It represents the hidden valid bit.
    ```
    syntax headerValue = HEADER tid `{ bool fieldValue* }
    ```
    Following the P4 specification, initialized header values are valid and the default value for header values is invalid.