### PR TITLE
Allow extern, parser, control, and package types to be aliased by typedef declarations

### DIFF
--- a/excludes/exclude-spec-discussion/nest-typedef-object.exclude
+++ b/excludes/exclude-spec-discussion/nest-typedef-object.exclude
@@ -1,4 +1,0 @@
-p4c/testdata/p4_16_samples/extern-inst-as-param.p4
-p4c/testdata/p4_16_samples/issue2735-bmv2.p4
-p4c/testdata/p4_16_samples/issue2735.p4
-p4c/testdata/p4_16_samples/typedef-constructor.p4

--- a/spec-concrete/4-ir-syntax.watsup
+++ b/spec-concrete/4-ir-syntax.watsup
@@ -18,6 +18,16 @@ dec $flatten_prefixedNameIR(prefixedNameIR) : nameIR
 def $flatten_prefixedNameIR(`` nameIR) = nameIR
 def $flatten_prefixedNameIR(`. nameIR) = "." ++ nameIR
 
+dec $get_type_name(type): nameIR?
+def $get_type_name(prefixedTypeName) = nameIR
+  -- if prefixedNameIR = $prefixedTypeName(prefixedTypeName)
+  -- if nameIR = $flatten_prefixedNameIR(prefixedNameIR)
+def $get_type_name(specializedType) = nameIR
+  -- if prefixedTypeName `< _ > = specializedType
+  -- if nameIR = $get_type_name(prefixedTypeName)
+def $get_type_name(type) = eps
+  -- otherwise
+
 syntax nameListIR = nameIR*
 
 ;;

--- a/spec-concrete/5.02-context.watsup
+++ b/spec-concrete/5.02-context.watsup
@@ -324,6 +324,64 @@ def $add_constructor(TC, cid, constructorTypeDefIR) = TC'
         = $add_map<cid, constructorTypeDefIR>(cdenv, cid, constructorTypeDefIR)
   -- if TC' = TC [ .GLOBAL.CDENV = cdenv_update ]
 
+dec $add_constructors(typingContext, cid*, constructorTypeDefIR*) : typingContext
+
+def $add_constructors(TC, eps, eps) = TC
+def $add_constructors(
+    TC,
+    cid_h :: cid_t*,
+    constructorTypeDefIR_h :: constructorTypeDefIR_t*
+  )
+  = TC''
+  -- if TC' = $add_constructor(TC, cid_h, constructorTypeDefIR_h)
+  -- if TC'' = $add_constructors(TC', cid_t*, constructorTypeDefIR_t*)
+
+;;; Adder for constructors from typedef declarations
+dec $add_typedef_constructors(typingContext, nameIR, nameIR, typeIR) : typingContext
+dec $get_typedef_constructors(cid*, constructorTypeDefIR*, nameIR, nameIR, typeIR)
+    : (cid*, constructorTypeDefIR*)
+
+def $add_typedef_constructors(TC, nameIR, nameIR_base, typeIR) = TC'
+  -- if `{ (cid `: constructorTypeDefIR)* } = TC.GLOBAL.CDENV
+  -- if (cid_typedef*, constructorTypeDefIR_typedef*)
+      = $get_typedef_constructors(cid*, constructorTypeDefIR*, nameIR, nameIR_base, typeIR)
+  -- if TC' = $add_constructors(TC, cid_typedef*, constructorTypeDefIR_typedef*)
+
+def $get_typedef_constructors(eps, eps, nameIR, nameIR_base, typeIR) = (eps, eps)
+
+def $get_typedef_constructors(
+    cid_h :: cid_t*,
+    constructorTypeDefIR_h :: constructorTypeDefIR_t*,
+    nameIR,
+    nameIR_base,
+    typeIR
+  )
+  = (
+      cid_typedef_h :: cid_typedef_t*,
+      constructorTypeDefIR_typedef_h :: constructorTypeDefIR_typedef_t*
+    )
+  -- if id_base `( pid_base* ) = cid_h
+  -- if id_base = nameIR_base
+  -- if cid_typedef_h = nameIR `( pid_base* )
+  -- if constructorTypeIR_h `< _ `, _ > = constructorTypeDefIR_h
+  -- if CONSTRUCTOR `( constructorParameterTypeIR_h* ) `-> _ = constructorTypeIR_h
+  -- if constructorTypeIR_typedef_h
+      = CONSTRUCTOR `( constructorParameterTypeIR_h* ) `-> typeIR
+  -- if constructorTypeDefIR_typedef_h = constructorTypeIR_typedef_h `< eps `, eps >
+  -- if (cid_typedef_t*, constructorTypeDefIR_typedef_t*)
+      = $get_typedef_constructors(cid_t*, constructorTypeDefIR_t*, nameIR, nameIR_base, typeIR)
+
+def $get_typedef_constructors(
+    cid_h :: cid_t*,
+    constructorTypeDefIR_h :: constructorTypeDefIR_t*,
+    nameIR,
+    nameIR_base,
+    typeIR
+  )
+  = $get_typedef_constructors(cid_t*, constructorTypeDefIR_t*, nameIR, nameIR_base, typeIR)
+  -- if id_base `( _ ) = cid_h
+  -- if id_base =/= nameIR_base
+
 ;;
 ;; Finders
 ;;

--- a/spec-concrete/5.03-wellformed.watsup
+++ b/spec-concrete/5.03-wellformed.watsup
@@ -106,6 +106,10 @@ def $nestable'_typedef(numberTypeIR) = true
 def $nestable'_typedef(TID _) = true
 def $nestable'_typedef(TYPE _ _) = true
 def $nestable'_typedef(dataTypeIR) = true
+def $nestable'_typedef(externObjectTypeIR) = true
+def $nestable'_typedef(parserObjectTypeIR) = true
+def $nestable'_typedef(controlObjectTypeIR) = true
+def $nestable'_typedef(packageObjectTypeIR) = true
 def $nestable'_typedef(_) = false
   -- otherwise
 

--- a/spec-concrete/5.11-typing-declaration.watsup
+++ b/spec-concrete/5.11-typing-declaration.watsup
@@ -778,11 +778,33 @@ rule Decl_ok/typeDeclaration-typedefDeclaration-typedef-type:
   ---- ;; check type
   -- Type_ok: GLOBAL TC_0 |- type : typeIR `# eps
   -- Type_wf: $bound(GLOBAL, TC_0) |- typeIR
+  -- if ~$is_extern_object_typeIR($canon(typeIR)) 
+        /\ ~$is_package_object_typeIR($canon(typeIR))
   ---- ;; create typedef and add to context
   -- if nameIR = $name(name)
   -- if typeIR_typedef = TYPEDEF nameIR typeIR
   -- TypeDef_wf: $bound(GLOBAL, TC_0) |- typeIR_typedef
   -- if TC_1 = $add_type(GLOBAL, TC_0, nameIR, typeIR_typedef)
+  ---- ;; create IR
+  -- if typedefDeclarationIR
+      = annotationList TYPEDEF typeIR nameIR `;
+
+rule Decl_ok/typeDeclaration-typedefDeclaration-typedef-type-constructor:
+  GLOBAL TC_0 |- annotationList TYPEDEF type name `;
+               : TC_2 typedefDeclarationIR
+  ---- ;; check type
+  -- Type_ok: GLOBAL TC_0 |- type : typeIR `# eps
+  -- Type_wf: $bound(GLOBAL, TC_0) |- typeIR
+  -- if typeIR_base = $canon(typeIR)
+  -- if $is_extern_object_typeIR(typeIR_base) \/ $is_package_object_typeIR(typeIR_base)
+  ---- ;; create typedef and add to context
+  -- if nameIR = $name(name)
+  -- if typeIR_typedef = TYPEDEF nameIR typeIR
+  -- TypeDef_wf: $bound(GLOBAL, TC_0) |- typeIR_typedef
+  -- if TC_1 = $add_type(GLOBAL, TC_0, nameIR, typeIR_typedef)
+  ---- ;; create constructors from base type and add to context
+  -- if nameIR_base = $get_type_name(type)
+  -- if TC_2 = $add_typedef_constructors(TC_1, nameIR, nameIR_base, typeIR_base)
   ---- ;; create IR
   -- if typedefDeclarationIR
       = annotationList TYPEDEF typeIR nameIR `;


### PR DESCRIPTION
This PR allows extern, parser, control, and package types to be aliased by typedef declarations.
1. `$nestable'_typedef()`
    `$nestable'_typedef` is updated to return true for `extern`, `parser`, `control`, and `package` types.
2. Constructors for aliases of `extern` and `package` types
    When `extern` or `package` types are declared, their names are used as constructors in instantiations. Aliases of those types introduced by `typedef` declarations may also be used as constructors. `typedef` declarations of `extern` and `package` types are updated to also add new constructors with the new names.
    - `rule Decl_ok/typeDeclaration-typedefDeclaration-typedef-type-constructor` is similar to `rule Decl_ok/typeDeclaration-typedefDeclaration-typedef-type`, except that it adds new constructors to the typing context.
    - `$add_typedef_constructors()` finds the constructors of the base type of the `typedef` declaration and copies the information to add the corresponding constructor with the new name.

    With the above changes, `excludes/exclude-spec-discussion/nest-typedef-object.exclude` is removed. A new type name introduced by a `typedef` declaration for an `extern` or `package` type can be used as a constructor:
    ```
    extern MyCounter<I> {
        MyCounter(bit<32> size);
    }
    
    typedef bit<10> my_counter_index_t;
    typedef MyCounter<my_counter_index_t> my_counter_t;
    
    control Test() {
        my_counter_t(1024) counter_set;
    		...
    }
    ```
3. Limitations
    Type checking fails when a type that consists of a don’t care type (”`_`”) as a type argument appears as a base type in a `typedef` declaration. For example, this `typedef` declaration is currently not allowed:
    ```
    package Switch<T>(Ingress<T, _, _> ingress, Egress<T, _, _> egress);
    typedef Switch<bit<32>> my_switch_t;
    ```